### PR TITLE
Recursively resolve/add fields to schema

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -45,7 +45,7 @@ services:
       - { name: service_collector, tag: graphql_type_resolver, call: addTypeResolver }
   graphql.type_resolver.entity:
     class: Drupal\graphql\TypeResolver\EntityTypeResolver
-    arguments: ['@entity_type.manager', '@typed_data_manager', '@graphql.type_resolver']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@typed_data_manager', '@graphql.type_resolver']
     tags:
       - { name: graphql_type_resolver }
   graphql.page_display_variant_subscriber:

--- a/src/GraphQL/Field/Entity/EntityBooleanField.php
+++ b/src/GraphQL/Field/Entity/EntityBooleanField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Field\Entity;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\graphql\GraphQL\Field\FieldBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Type\Scalar\BooleanType;
+
+class EntityBooleanField extends FieldBase {
+  /**
+   * Constructs an EntityBooleanField object.
+   */
+  public function __construct($fieldDefinition) {
+    $config = [
+      'name' => $fieldDefinition->getName(),
+      'type' => new BooleanType()
+    ];
+
+    parent::__construct($config);
+  }
+
+  /**
+   * Resolve function for this field.
+   *
+   * Loads the entity id for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $value
+   *   The parent value (entity object). May not use language-level type hinting
+   *   to keep compatibility with the parent implementation.
+   * @param array $args
+   *   The field arguments.
+   * @param \Youshido\GraphQL\Execution\ResolveInfo $info
+   *   The context information for which to resolve.
+   *
+   * @return @TODO
+   *   @TODO
+   */
+  public function resolve($value, array $args, ResolveInfo $info) {
+    return $value->get($this->getName())->getValue();
+  }
+}

--- a/src/GraphQL/Field/Entity/EntityEmailField.php
+++ b/src/GraphQL/Field/Entity/EntityEmailField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Field\Entity;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\graphql\GraphQL\Field\FieldBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Type\Scalar\StringType;
+
+class EntityEmailField extends FieldBase {
+  /**
+   * Constructs an EntityEmailField object.
+   */
+  public function __construct($fieldDefinition) {
+    $config = [
+      'name' => $fieldDefinition->getName(),
+      'type' => new StringType()
+    ];
+
+    parent::__construct($config);
+  }
+
+  /**
+   * Resolve function for this field.
+   *
+   * Loads the entity id for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $value
+   *   The parent value (entity object). May not use language-level type hinting
+   *   to keep compatibility with the parent implementation.
+   * @param array $args
+   *   The field arguments.
+   * @param \Youshido\GraphQL\Execution\ResolveInfo $info
+   *   The context information for which to resolve.
+   *
+   * @return @TODO
+   *   @TODO
+   */
+  public function resolve($value, array $args, ResolveInfo $info) {
+    return $value->get($this->getName())->getValue();
+  }
+}

--- a/src/GraphQL/Field/Entity/EntityIntegerField.php
+++ b/src/GraphQL/Field/Entity/EntityIntegerField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Field\Entity;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\graphql\GraphQL\Field\FieldBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Type\Scalar\IntType;
+
+class EntityIntegerField extends FieldBase {
+  /**
+   * Constructs an EntityIntegerField object.
+   */
+  public function __construct($fieldDefinition) {
+    $config = [
+      'name' => $fieldDefinition->getName(),
+      'type' => new IntType()
+    ];
+
+    parent::__construct($config);
+  }
+
+  /**
+   * Resolve function for this field.
+   *
+   * Loads the entity id for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $value
+   *   The parent value (entity object). May not use language-level type hinting
+   *   to keep compatibility with the parent implementation.
+   * @param array $args
+   *   The field arguments.
+   * @param \Youshido\GraphQL\Execution\ResolveInfo $info
+   *   The context information for which to resolve.
+   *
+   * @return @TODO
+   *   @TODO
+   */
+  public function resolve($value, array $args, ResolveInfo $info) {
+    return $value->get($this->getName());
+  }
+}

--- a/src/GraphQL/Field/Entity/EntityStringField.php
+++ b/src/GraphQL/Field/Entity/EntityStringField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Field\Entity;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\graphql\GraphQL\Field\FieldBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Type\Scalar\StringType;
+
+class EntityStringField extends FieldBase {
+  /**
+   * Constructs an EntityStringField object.
+   */
+  public function __construct($fieldDefinition) {
+    $config = [
+      'name' => $fieldDefinition->getName(),
+      'type' => new StringType()
+    ];
+
+    parent::__construct($config);
+  }
+
+  /**
+   * Resolve function for this field.
+   *
+   * Loads the entity id for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $value
+   *   The parent value (entity object). May not use language-level type hinting
+   *   to keep compatibility with the parent implementation.
+   * @param array $args
+   *   The field arguments.
+   * @param \Youshido\GraphQL\Execution\ResolveInfo $info
+   *   The context information for which to resolve.
+   *
+   * @return @TODO
+   *   @TODO
+   */
+  public function resolve($value, array $args, ResolveInfo $info) {
+    return $value->get($this->getName())->getValue();
+  }
+}

--- a/src/GraphQL/Type/Entity/EntityObjectType.php
+++ b/src/GraphQL/Type/Entity/EntityObjectType.php
@@ -11,6 +11,9 @@ use Drupal\graphql\GraphQL\Type\AbstractObjectType;
 use Drupal\graphql\Utility\StringHelper;
 
 class EntityObjectType extends AbstractObjectType {
+
+  protected $fieldDefinitions;
+
   /**
    * Creates an EntityObjectType instance.
    *
@@ -18,9 +21,12 @@ class EntityObjectType extends AbstractObjectType {
    *   The entity type definition for this object type.
    * @param string $bundle
    *   The entity bundle.
+   * @param array $fieldDefinitions
+   *   The entity field definitions.
    */
-  public function __construct(EntityTypeInterface $entityType, $bundle) {
+  public function __construct(EntityTypeInterface $entityType, $bundle, $fieldDefinitions) {
     $entityTypeId = $entityType->id();
+    $this->fieldDefinitions = $fieldDefinitions;
     $typeName = StringHelper::formatTypeName("$entityTypeId:$bundle");
 
     $config = [
@@ -30,14 +36,24 @@ class EntityObjectType extends AbstractObjectType {
         new EntityInterfaceType(),
         new EntitySpecificInterfaceType($entityType),
       ],
-      // @todo Figure out how and where to use the typed data property definitions to build the fields array.
       'fields' => [
         'id' => new GlobalIdField("entity/$entityTypeId"),
         'entityId' => new EntityIdField(),
-        'entityType' => new EntityTypeField(),
-      ],
+        'entityType' => new EntityTypeField()
+      ] 
     ];
 
     parent::__construct($config);
+  }
+
+  public function build($config){
+    $fieldDefinitions = $this->fieldDefinitions;
+    foreach ($fieldDefinitions as $fieldDefinition) {
+      // Resolve Field
+      $className = "Drupal\graphql\GraphQL\Field\Entity\Entity" . ucfirst($fieldDefinition->getType()) . "Field";
+      if (class_exists($className)) {
+        $config->addfield(new $className($fieldDefinition));
+      }
+    }
   }
 }

--- a/src/GraphQL/Type/Entity/EntityObjectType.php
+++ b/src/GraphQL/Type/Entity/EntityObjectType.php
@@ -12,6 +12,9 @@ use Drupal\graphql\Utility\StringHelper;
 
 class EntityObjectType extends AbstractObjectType {
 
+  /**
+   * Field definitions
+   */
   protected $fieldDefinitions;
 
   /**
@@ -46,10 +49,12 @@ class EntityObjectType extends AbstractObjectType {
     parent::__construct($config);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function build($config){
-    $fieldDefinitions = $this->fieldDefinitions;
-    foreach ($fieldDefinitions as $fieldDefinition) {
-      // Resolve Field
+    foreach ($this->fieldDefinitions as $fieldDefinition) {
+      // Have a better resolver here, this is just for proof of concept. Doesn't even work for types with _ at the moment.
       $className = "Drupal\graphql\GraphQL\Field\Entity\Entity" . ucfirst($fieldDefinition->getType()) . "Field";
       if (class_exists($className)) {
         $config->addfield(new $className($fieldDefinition));

--- a/src/GraphQL/Type/Entity/EntitySpecificInterfaceType.php
+++ b/src/GraphQL/Type/Entity/EntitySpecificInterfaceType.php
@@ -39,7 +39,7 @@ class EntitySpecificInterfaceType extends AbstractInterfaceType {
   public function resolveType($object) {
     // @todo Use the type resolver service here instead.
     if ($object instanceof EntityInterface) {
-      return new EntityObjectType($object->getEntityType(), $object->bundle());
+      return new EntityObjectType($object->getEntityType(), $object->bundle(), $object->getFieldDefinitions());
     }
 
     return NULL;


### PR DESCRIPTION
Not intended for merging, only discussion. 

This approach follows the idea we talked about in our first meeting where we keep Drupal's services out of the GraphQL object classes. In this example, `EntityObjectType` accepts a third argument: an array of field definitions. 

I added the `entity_field.manager` service to the `EntityTypeResolver` to get the field definitions to pass to the `EntityObjectType` (using the `getFieldDefinitions()` method).

In addition to being passed definitions by the `EntityTypeResolver`, it gets field definitions if being resolved by `EntitySecificInterfaceType` using the same mechanism but through different means. An instantiated Entity object has the `getFieldDefinitions()` method available to it which also uses the `EntityFieldManager` (though it is through the `EntityManager`). 

I added some example classes and a basic field resolver to the `EntityObjectType` class to facilitate discussion - I'm sure there's a better way to handle resolving of GraphQL field classes. 