### PR TITLE
Only cache cacheable results

### DIFF
--- a/src/Controller/RequestController.php
+++ b/src/Controller/RequestController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Config\Config;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\graphql\GraphQL\Execution\Processor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Youshido\GraphQL\Schema\AbstractSchema;
@@ -98,15 +99,16 @@ class RequestController implements ContainerInjectionInterface {
 
     // @todo This needs proper, context and tag based caching logic.
     //
-    // We need to add cache contexts and tags from the resolver functions in the
-    // schema and figure out a way to make this work with the dynamic page cache
+    // We need to figure out a way to make this work with the dynamic page cache
     // and fractional caching. For now, we only cache for anonymous users via
     // the custom CacheSubscriber provided by this module. Not cool.
     $metadata = new CacheableMetadata();
+    // Default to permanent cache.
     $metadata->setCacheMaxAge(Cache::PERMANENT);
+    // Add cache metadata from the processor and result stages.
     $metadata->addCacheableDependency($processor);
-
-    // Add the cache metadata into the response object.
+    $metadata->addCacheableDependency($result);
+    // Apply the metadata to the response object.
     $response->addCacheableDependency($metadata);
 
     // Set the execution context on the request attributes for use in the

--- a/src/GraphQL/Execution/Processor.php
+++ b/src/GraphQL/Execution/Processor.php
@@ -54,6 +54,10 @@ class Processor extends BaseProcessor implements CacheableDependencyInterface {
     if ($value instanceof CacheableDependencyInterface) {
       $this->metadata->addCacheableDependency($value);
     }
+    else {
+      // If any individual result is not cacheable, neither is the whole result.
+      $this->metadata->setCacheMaxAge(0);
+    }
 
     return $value;
   }


### PR DESCRIPTION
* Apply cacheability metadata from the response and processor to the JSON response. If the response had a bunch of cache tags, the JSON response needs them too.
* During processing, if any one query result is not cacheable, mark the whole result as not cacheable.

Together, this means that cacheability metadata will bubble up from the resolver and resolved objects. We will only cache JSON results that are actually cacheable.

I considered removing the whole @todo at src/RequestController.php:100 , but this doesn't quite resolve the WHOLE todo. There are probably some context/tags we want to add, unique to GraphQL requests. Modified the todo comment accordingly.