### PR TITLE
Remove Node module dependency from QueryTestBase

### DIFF
--- a/tests/src/Functional/NodeSchemaTest.php
+++ b/tests/src/Functional/NodeSchemaTest.php
@@ -3,6 +3,8 @@
 namespace Drupal\Tests\graphql\Functional;
 
 use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\simpletest\NodeCreationTrait;
 
 /**
  * Tests some custom schema.
@@ -10,6 +12,12 @@ use Drupal\node\Entity\Node;
  * @group GraphQL
  */
 class NodeSchemaTest extends QueryTestBase  {
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['node'];
 
   /**
    * @var \Drupal\node\NodeInterface
@@ -18,6 +26,13 @@ class NodeSchemaTest extends QueryTestBase  {
 
   public function setUp() {
     parent::setUp();
+
+    // Create a test content type for node testing.
+    NodeType::create([
+      'name' => 'article',
+      'type' => 'article',
+    ])->save();
+
     $node = Node::create([
       'type' => 'article',
       'title' => 'giraffe',

--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -2,19 +2,15 @@
 
 namespace Drupal\Tests\graphql\Functional;
 
-use Drupal\node\Entity\NodeType;
 use Drupal\simpletest\BrowserTestBase;
-use Drupal\simpletest\NodeCreationTrait;
 use Drupal\user\Entity\Role;
 
 abstract class QueryTestBase extends BrowserTestBase {
 
-  use NodeCreationTrait;
-
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['graphql', 'node'];
+  public static $modules = ['graphql'];
 
   /**
    * The GraphQL resource.
@@ -35,12 +31,6 @@ abstract class QueryTestBase extends BrowserTestBase {
     Role::load('anonymous')
       ->grantPermission('execute graphql requests')
       ->save();
-
-    // Create a test content type for node testing.
-    NodeType::create([
-      'name' => 'article',
-      'type' => 'article',
-    ])->save();
   }
 
   /**


### PR DESCRIPTION
It is useful to be able to create tests without dependency to Node module. That is especially important in cases where node module is not enabled on the site normally.