### PR TITLE
Use session in QueryTestBase to allow testing features that require logged in user

### DIFF
--- a/tests/modules/graphql_test_custom_schema/src/Fields/CurrentUserField.php
+++ b/tests/modules/graphql_test_custom_schema/src/Fields/CurrentUserField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql_test_custom_schema\Fields;
+
+use Drupal\graphql_test_custom_schema\Types\UserType;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Field\AbstractField;
+
+/**
+ * Provides a current user field.
+ */
+class CurrentUserField extends AbstractField implements ContainerAwareInterface {
+  use ContainerAwareTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve($value, array $args, ResolveInfo $info) :UserInterface {
+    $account = $this->container->get('current_user')->getAccount();
+    $user = $this->container->get('entity_type.manager')->getStorage('user')->load($account->id());
+
+    return $user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'currentUser';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return new UserType();
+  }
+
+}

--- a/tests/modules/graphql_test_custom_schema/src/Fields/UsernameField.php
+++ b/tests/modules/graphql_test_custom_schema/src/Fields/UsernameField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\graphql_test_custom_schema\Fields;
+
+use Drupal\graphql\GraphQL\CacheableValue;
+use Drupal\user\UserInterface;
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Type\NonNullType;
+use Youshido\GraphQL\Type\Scalar\StringType;
+
+/**
+ * Provides an entity label field.
+ */
+class UsernameField extends AbstractField {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve($value, array $args, ResolveInfo $info) {
+    if ($value instanceof UserInterface) {
+      return new CacheableValue($value->getDisplayName(), [$value]);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return new NonNullType(new StringType());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'username';
+  }
+
+}

--- a/tests/modules/graphql_test_custom_schema/src/NodeField.php
+++ b/tests/modules/graphql_test_custom_schema/src/NodeField.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\graphql_test_custom_schema;
 
+use Drupal\graphql_test_custom_schema\Types\UserType;
 use Drupal\node\NodeInterface;
 use Drupal\graphql\GraphQL\Relay\Field\NodeField as NodeFieldBase;
 use Drupal\graphql_test_custom_schema\Types\ArticleType;
+use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Relay\Fetcher\FetcherInterface;
@@ -39,6 +41,11 @@ class NodeField extends NodeFieldBase implements ContainerAwareInterface, Fetche
         return $entityTypeManager
           ->getStorage('node')
           ->load($id);
+
+      case 'user':
+        return $entityTypeManager
+          ->getStorage('user')
+          ->load($id);
     }
 
     return NULL;
@@ -53,6 +60,10 @@ class NodeField extends NodeFieldBase implements ContainerAwareInterface, Fetche
         case 'sane_article':
           return new ArticleType();
       }
+    }
+
+    if ($object instanceof UserInterface) {
+      return new UserType();
     }
 
     return NULL;

--- a/tests/modules/graphql_test_custom_schema/src/SchemaProvider.php
+++ b/tests/modules/graphql_test_custom_schema/src/SchemaProvider.php
@@ -2,14 +2,17 @@
 
 namespace Drupal\graphql_test_custom_schema;
 
-use Drupal\graphql\SchemaProviderInterface;
+use Drupal\graphql\SchemaProvider\SchemaProviderInterface;
+use Drupal\graphql_test_custom_schema\Fields\CurrentUserField;
 
 class SchemaProvider implements SchemaProviderInterface {
+
   /**
    * {@inheritdoc}
    */
   public function getQuerySchema() {
     return [
+      new CurrentUserField(),
     ];
   }
 

--- a/tests/modules/graphql_test_custom_schema/src/Types/UserType.php
+++ b/tests/modules/graphql_test_custom_schema/src/Types/UserType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\graphql_test_custom_schema\Types;
+
+use Drupal\graphql\GraphQL\Relay\Field\GlobalIdField;
+use Drupal\graphql\GraphQL\Type\AbstractObjectType;
+use Drupal\graphql_test_custom_schema\Fields\UsernameField;
+
+/**
+ * Defines user data type.
+ */
+class UserType extends AbstractObjectType {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build($config) {
+    $config->addField(new GlobalIdField('user'));
+    $config->addField(new UsernameField());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'User';
+  }
+
+}

--- a/tests/src/Functional/CurrentUserTest.php
+++ b/tests/src/Functional/CurrentUserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\graphql\Functional;
+
+/**
+ * Tests currentUser field.
+ *
+ * @group GraphQL
+ */
+class CurrentUserTest extends QueryTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['graphql_test_custom_schema'];
+
+  /**
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->user = $this->drupalCreateUser(['execute graphql requests'], 'kitten');
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * @covers \Drupal\aava_cm\GraphQL\Field\Root\CurrentUserField
+   */
+  public function testCurrentUser() {
+    $query = <<<GQL
+{
+  currentUser() {
+    username
+  }
+}
+    
+GQL;
+
+    $body = $this->query($query);
+    $data = json_decode($body, TRUE);
+    $this->assertEquals([
+      'data' => [
+        'currentUser' => [
+          'username' => $this->user->getDisplayName(),
+        ],
+      ],
+    ], $data);
+  }
+
+}

--- a/tests/src/Functional/CurrentUserTest.php
+++ b/tests/src/Functional/CurrentUserTest.php
@@ -30,7 +30,7 @@ class CurrentUserTest extends QueryTestBase {
   }
 
   /**
-   * @covers \Drupal\aava_cm\GraphQL\Field\Root\CurrentUserField
+   * @covers \Drupal\Tests\graphql\Functional\QueryTestBase::query
    */
   public function testCurrentUser() {
     $query = <<<GQL

--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -58,7 +58,7 @@ abstract class QueryTestBase extends BrowserTestBase {
     $cookie = new SetCookie();
     $cookie->setName($this->getSessionName());
     $cookie->setValue($minkSession);
-    $cookie->setDomain(parse_url($this->baseUrl)['host']);
+    $cookie->setDomain(parse_url($this->baseUrl, PHP_URL_HOST));
 
     $jar = new CookieJar();
     $jar->setCookie($cookie);

--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -53,11 +53,11 @@ abstract class QueryTestBase extends BrowserTestBase {
     ];
 
     // Ensure that requests are made in the right session.
-    $mink_session = $this->getSession()->getCookie($this->getSessionName());
+    $minkSession = $this->getSession()->getCookie($this->getSessionName());
 
     $cookie = new SetCookie();
     $cookie->setName($this->getSessionName());
-    $cookie->setValue($mink_session);
+    $cookie->setValue($minkSession);
     $cookie->setDomain(parse_url($this->baseUrl)['host']);
 
     $jar = new CookieJar();

--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\graphql\Functional;
 
 use Drupal\simpletest\BrowserTestBase;
 use Drupal\user\Entity\Role;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
 
 abstract class QueryTestBase extends BrowserTestBase {
 
@@ -50,8 +52,20 @@ abstract class QueryTestBase extends BrowserTestBase {
       'operation' => $operation,
     ];
 
+    // Ensure that requests are made in the right session.
+    $mink_session = $this->getSession()->getCookie($this->getSessionName());
+
+    $cookie = new SetCookie();
+    $cookie->setName($this->getSessionName());
+    $cookie->setValue($mink_session);
+    $cookie->setDomain(parse_url($this->baseUrl)['host']);
+
+    $jar = new CookieJar();
+    $jar->setCookie($cookie);
+
     $response = \Drupal::httpClient()->post($this->getAbsoluteUrl($this->queryUrl), [
       'body' => json_encode($body),
+      'cookies' => $jar,
     ]);
 
     return (string) $response->getBody();


### PR DESCRIPTION
QueryTestBase makes its request always with a new session which prevents logging in. After this change, the requests will be made using the same session that Mink uses.

If we want to further develop this, we might want to allow sharing the cookies between multiple requests in a single test case. This doesn't still address that.