### PR TITLE
GraphQL configuration and extensions page

### DIFF
--- a/graphql.info.yml
+++ b/graphql.info.yml
@@ -2,4 +2,5 @@ name: GraphQL
 type: module
 description: 'Exposes your Drupal data model through a GraphQL schema.'
 package: Web services
+configure: graphql.config_page
 core: 8.x

--- a/graphql.links.menu.yml
+++ b/graphql.links.menu.yml
@@ -3,3 +3,8 @@ entity.graphql_query_map.collection:
   route_name: entity.graphql_query_map.collection
   description: 'Configure GraphQL Query Maps.'
   parent: system.admin_structure
+graphql.config_page:
+  title: 'GraphQL'
+  description: 'GraphQL settings and extensions.'
+  parent: 'system.admin_config_services'
+  route_name: graphql.config_page

--- a/graphql.routing.yml
+++ b/graphql.routing.yml
@@ -7,6 +7,13 @@ graphql.request:
   requirements:
     _permission: 'execute graphql requests'
 
+graphql.config_page:
+  path: '/admin/config/graphql'
+  defaults:
+    _controller: '\Drupal\graphql\Controller\GraphQLConfig::configPageRoot'
+    _title: 'GraphQL'
+  requirements:
+    _permission: 'administer site configuration'
 graphql.explorer:
   path: '/graphql/explorer'
   defaults:

--- a/src/Controller/GraphQLConfig.php
+++ b/src/Controller/GraphQLConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\graphql\Controller;
+
+use Drupal\Core\Url;
+
+/**
+ * Controller for the GraphiQL configuration page.
+ */
+class GraphQLConfig {
+
+  /**
+   * Displaying the links in GraphQL configuration page.
+   *
+   * A place to render all GraphQL related links.
+   *
+   * @return array
+   *   Rendered links in admin_block_content theme.
+   */
+  public function configPageRoot() {
+    $links = [
+      [
+        'title' => 'GraphiQL Explorer',
+        'url' => Url::fromRoute('graphql.explorer'),
+        'description' => t('An in-browser IDE for exploring GraphQL.'),
+        'localized_options' => [],
+      ],
+      [
+        'title' => 'GraphQL Query Maps',
+        'url' => Url::fromRoute('entity.graphql_query_map.collection'),
+        'description' => t('Configure GraphQL Query Maps.'),
+        'localized_options' => [],
+      ],
+    ];
+
+    return array(
+      '#theme' => 'admin_block_content',
+      '#content' => $links,
+    );
+  }
+}


### PR DESCRIPTION
GraphQL module is currently missing a configuration and extensions page.

There is no direct link to GraphiQL (Explorer) from any page in the system, GraphQL Query Maps could be moved to this configuration page and all future contrib modules will need a GraphQL "root" page to hang the links there so everything is under one roof.

This is what this PR does:

![graphql_config_page](https://cloud.githubusercontent.com/assets/426177/24399094/e538f4fe-13ab-11e7-8950-60a4c69a1a92.png)

The next link could be GraphQL Voyager for example. As contrib module.
https://apis.guru/graphql-voyager/

Drupal.org clone issue: https://www.drupal.org/node/2864636

