### PR TITLE
Extend the new Test\BrowserTestBase instead of Simpletest\BrowserTest…

### DIFF
--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\graphql\Functional;
 
-use Drupal\simpletest\BrowserTestBase;
+use Drupal\Tests\BrowserTestBase;
 use Drupal\user\Entity\Role;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;


### PR DESCRIPTION
…Base class

Not sure this fixes the build fail, but I noticed that is was extending the old simpeltest base class.
Havn't set up my phpStorm to run a unit test at the moment, but I guess travis will test this.

If this does not work, just trow my PR away ;)