### PR TITLE
Simplify ImageStyle url schema, add itok token

### DIFF
--- a/modules/graphql_file/src/Plugin/GraphQL/Fields/FileUrl.php
+++ b/modules/graphql_file/src/Plugin/GraphQL/Fields/FileUrl.php
@@ -12,7 +12,6 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  * @GraphQLField(
  *   name = "url",
  *   type = "String",
- *   nullable = true,
  *   types = {"File"}
  * )
  */

--- a/modules/graphql_file/src/Plugin/GraphQL/Fields/FileUrl.php
+++ b/modules/graphql_file/src/Plugin/GraphQL/Fields/FileUrl.php
@@ -2,28 +2,28 @@
 
 namespace Drupal\graphql_file\Plugin\GraphQL\Fields;
 
-use Drupal\Core\Url;
 use Drupal\file\FileInterface;
-use Drupal\graphql_content\Plugin\GraphQL\Fields\EntityUrl;
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
 use Youshido\GraphQL\Execution\ResolveInfo;
 
 /**
  * Entity route field override for files.
  *
  * @GraphQLField(
- *   name = "entityUrl",
- *   type = "Url",
+ *   name = "url",
+ *   type = "String",
+ *   nullable = true,
  *   types = {"File"}
  * )
  */
-class FileUrl extends EntityUrl {
+class FileUrl extends FieldPluginBase {
 
   /**
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveInfo $info) {
     if ($value instanceof FileInterface) {
-      yield Url::fromUri($value->url());
+      yield file_create_url($value->getFileUri());
     }
   }
 

--- a/modules/graphql_file/tests/queries/files.gql
+++ b/modules/graphql_file/tests/queries/files.gql
@@ -2,10 +2,7 @@ query ($path: String!) {
   route:route(path: $path) {
     node:entity {
       file {
-        entityUrl {
-          internalPath:path
-          routed
-        }
+        url
         fileSize
         mimeType
       }

--- a/modules/graphql_file/tests/src/Kernel/FileFieldTest.php
+++ b/modules/graphql_file/tests/src/Kernel/FileFieldTest.php
@@ -93,8 +93,7 @@ class FileFieldTest extends GraphQLFileTest {
 
     $this->assertEquals($a->file->entity->getSize(), $file['fileSize'], 'Retrieve correct file size.');
     $this->assertEquals($a->file->entity->getMimeType(), $file['mimeType'], 'Retrieve correct mime type.');
-    $this->assertEquals($a->file->entity->url(), $file['entityUrl']['internalPath'], 'Retrieve correct file path.');
-    $this->assertFalse($file['entityUrl']['routed'], 'File urls are not routed.');
+    $this->assertEquals($a->file->entity->toUrl(), $file['url'], 'Retrieve correct file path.');
   }
 
 }

--- a/modules/graphql_file/tests/src/Kernel/FileFieldTest.php
+++ b/modules/graphql_file/tests/src/Kernel/FileFieldTest.php
@@ -93,7 +93,7 @@ class FileFieldTest extends GraphQLFileTest {
 
     $this->assertEquals($a->file->entity->getSize(), $file['fileSize'], 'Retrieve correct file size.');
     $this->assertEquals($a->file->entity->getMimeType(), $file['mimeType'], 'Retrieve correct mime type.');
-    $this->assertEquals($a->file->entity->toUrl(), $file['url'], 'Retrieve correct file path.');
+    $this->assertEquals($a->file->entity->url(), $file['url'], 'Retrieve correct file path.');
   }
 
 }

--- a/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageStyle.php
+++ b/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageStyle.php
@@ -5,6 +5,7 @@ namespace Drupal\graphql_image\Plugin\GraphQL\Fields;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Image\ImageFactory;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\graphql_core\GraphQL\FieldPluginBase;
 use Drupal\image\Plugin\Field\FieldType\ImageItem;
@@ -85,7 +86,7 @@ class ImageStyle extends FieldPluginBase implements ContainerFactoryPluginInterf
         // Return null if derivative generation didn't succeed.
         if ($derivative->isValid()) {
           yield [
-            'uri' => $style ? $style->buildUri($file->getFileUri()) : $file->getFileUri(),
+            'url' => $style ? $style->buildUrl($file->getFileUri()) : Url::fromUri(file_create_url($file->getFileUri()))->toString(),
             'mimeType' => $derivative->getMimeType(),
             'width' => $derivative->getWidth(),
             'height' => $derivative->getHeight(),

--- a/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageStyleUrl.php
+++ b/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageStyleUrl.php
@@ -7,11 +7,11 @@ use Drupal\graphql_core\GraphQL\FieldPluginBase;
 use Youshido\GraphQL\Execution\ResolveInfo;
 
 /**
- * Retrieve the image width.
+ * Retrieve the image url.
  *
  * @GraphQLField(
  *   name = "url",
- *   type = "Url",
+ *   type = "String",
  *   nullable = true,
  *   types = {"ImageStyle"}
  * )
@@ -22,8 +22,8 @@ class ImageStyleUrl extends FieldPluginBase {
    * {@inheritdoc}
    */
   protected function resolveValues($value, array $args, ResolveInfo $info) {
-    if (array_key_exists('uri', $value)) {
-      yield Url::fromUri(file_create_url($value['uri']));
+    if (array_key_exists('url', $value)) {
+      yield $value['url'];
     }
   }
 

--- a/modules/graphql_image/tests/queries/image.gql
+++ b/modules/graphql_image/tests/queries/image.gql
@@ -9,20 +9,14 @@ query ($path: String!) {
           mimeType
           width
           height
-          route:url {
-            internalPath:path
-            isRouted:routed
-          }
+          url
         }
         thumbnailImage {
           fileSize
           mimeType
           width
           height
-          route:url {
-            internalPath:path
-            isRouted:routed
-          }
+          url
         }
       }
     }

--- a/modules/graphql_image/tests/src/Kernel/ImageFieldTest.php
+++ b/modules/graphql_image/tests/src/Kernel/ImageFieldTest.php
@@ -96,7 +96,7 @@ class ImageFieldTest extends GraphQLFileTest {
 
     $this->assertEquals($a->image->alt, $image['alt'], 'Alt text correct.');
     $this->assertEquals($a->image->title, $image['title'], 'Title text correct.');
-    $this->assertEquals($a->image->entity->toUrl()->toString(), $image['originalImage']['url'], 'Retrieve correct image url.');
+    $this->assertEquals($a->image->entity->url(), $image['originalImage']['url'], 'Retrieve correct image url.');
   }
 
 }

--- a/modules/graphql_image/tests/src/Kernel/ImageFieldTest.php
+++ b/modules/graphql_image/tests/src/Kernel/ImageFieldTest.php
@@ -96,9 +96,7 @@ class ImageFieldTest extends GraphQLFileTest {
 
     $this->assertEquals($a->image->alt, $image['alt'], 'Alt text correct.');
     $this->assertEquals($a->image->title, $image['title'], 'Title text correct.');
-    $this->assertEquals($a->image->entity->url(), $image['originalImage']['route']['internalPath'], 'Retrieve correct image url.');
-    $this->assertFalse($image['originalImage']['route']['isRouted'], 'Image urls are not routed.');
-    $this->assertFalse($image['thumbnailImage']['route']['isRouted'], 'Image urls are not routed.');
+    $this->assertEquals($a->image->entity->toUrl()->toString(), $image['originalImage']['url'], 'Retrieve correct image url.');
   }
 
 }


### PR DESCRIPTION
The scheme for ImageStyles is quite complex, because the url is an full url object. I think it is possible to skip one level in the schema and return it as a string.

```
fieldImage {
  title
  alt
  originalImage {
    url {
      path
    } 
  }
  largeImage {
    url {
      path
    } 
  }
}
```

becomes

```
fieldImage {
  title
  alt
  originalImage {
    url
  }
  largeImage {
    url
  }
}
```

I changes the method from ``:: buildUri`` to ``:: buildUrl`` because of the additional itok parameter. ``:: buildUri`` is not meant to be used as external url.

PS: I am a total GraphQL newbie. I hope it makes sense.