### PR TITLE
Fix access check in EntityReferenceField

### DIFF
--- a/modules/graphql_entity_reference/src/Plugin/GraphQL/Fields/EntityReferenceField.php
+++ b/modules/graphql_entity_reference/src/Plugin/GraphQL/Fields/EntityReferenceField.php
@@ -25,7 +25,7 @@ class EntityReferenceField extends FieldPluginBase {
   public function resolveValues($value, array $args, ResolveInfo $info) {
     if ($value instanceof ContentEntityInterface) {
       foreach ($value->get($this->getPluginDefinition()['field']) as $item) {
-        if ($item instanceof EntityReferenceItem && $item->getEntity()->access('view')) {
+        if ($item instanceof EntityReferenceItem && $item->entity->access('view')) {
           yield $item->entity;
         }
       }


### PR DESCRIPTION
EntityReferenceItem::getEntity returns the parent entity. $item->entity returns the referenced entity in the field item.

// ping @pmelab 