### PR TITLE
WIP: Removed "fields" annotation property.

### DIFF
--- a/modules/graphql_content/src/Plugin/Deriver/EntityBundleDeriver.php
+++ b/modules/graphql_content/src/Plugin/Deriver/EntityBundleDeriver.php
@@ -61,7 +61,7 @@ class EntityBundleDeriver extends DeriverBase implements ContainerDeriverInterfa
           $this->derivatives[$typeId . '-' . $bundle] = [
             'name' => graphql_core_camelcase([$typeId, $bundle]),
             'entity_type' => $typeId,
-            'interfaces' => [graphql_core_camelcase($typeId), 'Entity'],
+            'interfaces' => [graphql_core_camelcase($typeId)],
             'bundle' => $bundle,
           ] + $basePluginDefinition;
         }

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityBundle.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityBundle.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_bundle",
  *   name = "entityBundle",
  *   type = "String",
+ *   types = {"Entity"}
  * )
  */
 class EntityBundle extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityId.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityId.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_id",
  *   name = "entityId",
  *   type = "Int",
+ *   types = {"Entity"}
  * )
  */
 class EntityId extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityLabel.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityLabel.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_label",
  *   name = "entityLabel",
  *   type = "String",
+ *   types = {"Entity"}
  * )
  */
 class EntityLabel extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityLanguage.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityLanguage.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_language",
  *   name = "entityLanguage",
  *   type = "Language",
+ *   types = {"Entity"}
  * )
  */
 class EntityLanguage extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityType.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityType.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_type",
  *   name = "entityType",
  *   type = "String",
+ *   types = {"Entity"}
  * )
  */
 class EntityType extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityUrl.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/EntityUrl.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_url",
  *   name = "entityUrl",
  *   type = "Url",
+ *   types = {"Entity"}
  * )
  */
 class EntityUrl extends FieldPluginBase {

--- a/modules/graphql_content/src/Plugin/GraphQL/Interfaces/EntityType.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Interfaces/EntityType.php
@@ -10,15 +10,6 @@ use Drupal\graphql_core\Plugin\GraphQL\Interfaces\Entity;
  * @GraphQLInterface(
  *   id = "entity_type",
  *   weight = -1,
- *   fields = {
- *     "entityId",
- *     "entityUuid",
- *     "entityLabel",
- *     "entityType",
- *     "entityBundle",
- *     "entityUrl",
- *     "entityLanguage"
- *   },
  *   cache_tags = {"entity_types"},
  *   deriver = "Drupal\graphql_content\Plugin\Deriver\EntityTypeDeriver"
  * )

--- a/modules/graphql_content/src/Plugin/GraphQL/Interfaces/EntityType.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Interfaces/EntityType.php
@@ -11,6 +11,7 @@ use Drupal\graphql_core\Plugin\GraphQL\Interfaces\Entity;
  *   id = "entity_type",
  *   weight = -1,
  *   cache_tags = {"entity_types"},
+ *   interfaces = {"Entity"},
  *   deriver = "Drupal\graphql_content\Plugin\Deriver\EntityTypeDeriver"
  * )
  */

--- a/modules/graphql_core/graphql_core.module
+++ b/modules/graphql_core/graphql_core.module
@@ -41,3 +41,58 @@ function graphql_core_camelcase($components) {
 function graphql_core_propcase($components) {
   return lcfirst(graphql_core_camelcase($components));
 }
+
+/**
+ * Implements hook_graphql_interfaces_alter().
+ *
+ * Flatten the interface inheritance tree.
+ */
+function graphql_core_graphql_interfaces_alter(&$definitions) {
+  $interfaces = array_map(function ($definition) use ($definitions) {
+    return graphql_core_list_interfaces($definitions, $definition);
+  }, $definitions);
+
+  foreach ($interfaces as $index => $list) {
+    $definition['interfaces'] = $list;
+  }
+}
+
+/**
+ * Implements hook_graphql_types_alter().
+ *
+ * Flatten the interface inheritance tree.
+ */
+function graphql_core_graphql_types_alter(&$definitions) {
+  $interface_definitions = \Drupal::service('graphql_core.interface_manager')->getDefinitions();
+
+  $interfaces = array_map(function ($definition) use ($interface_definitions) {
+    return graphql_core_list_interfaces($interface_definitions, $definition);
+  }, $definitions);
+
+  foreach ($interfaces as $index => $list) {
+    $definitions[$index]['interfaces'] = $list;
+  }
+}
+
+/**
+ * Get a flattened list of a plugins interface inheritance tree.
+ *
+ * @param array $definitions
+ *   The list of interface definitions.
+ * @param mixed $definition
+ *   A plugin definition.
+ *
+ * @return string[]
+ *   A list of interface names.
+ */
+function graphql_core_list_interfaces(array &$definitions, $definition) {
+  $parents = array_filter($definitions, function ($parent) use ($definition) {
+    return in_array($parent['name'], $definition['interfaces']);
+  });
+
+  $interfaces = array_reduce(array_map(function ($parent) use ($definitions) {
+    return graphql_core_list_interfaces($definitions, $parent);
+  }, $parents), 'array_merge', $definition['interfaces']);
+
+  return $interfaces;
+}

--- a/modules/graphql_core/src/Annotation/GraphQLInputType.php
+++ b/modules/graphql_core/src/Annotation/GraphQLInputType.php
@@ -14,11 +14,4 @@ class GraphQLInputType extends GraphQLAnnotationBase {
    */
   public $pluginType = GRAPHQL_CORE_INPUT_TYPE_PLUGIN;
 
-  /**
-   * The fields attached to this type.
-   *
-   * @var array
-   */
-  public $fields = [];
-
 }

--- a/modules/graphql_core/src/Annotation/GraphQLInterface.php
+++ b/modules/graphql_core/src/Annotation/GraphQLInterface.php
@@ -21,4 +21,13 @@ class GraphQLInterface extends GraphQLAnnotationBase {
    */
   public $data_type;
 
+  /**
+   * The list of parent interfaces this interface extends.
+   *
+   * Fields attached to interfaces will be inherited.
+   *
+   * @var string[]
+   */
+  public $interfaces = [];
+
 }

--- a/modules/graphql_core/src/Annotation/GraphQLInterface.php
+++ b/modules/graphql_core/src/Annotation/GraphQLInterface.php
@@ -19,13 +19,6 @@ class GraphQLInterface extends GraphQLAnnotationBase {
    *
    * @var string
    */
-  public $data_type;
-
-  /**
-   * The fields attached to this interface.
-   *
-   * @var array
-   */
-  public $fields = [];
+  public $dataType;
 
 }

--- a/modules/graphql_core/src/Annotation/GraphQLInterface.php
+++ b/modules/graphql_core/src/Annotation/GraphQLInterface.php
@@ -19,6 +19,6 @@ class GraphQLInterface extends GraphQLAnnotationBase {
    *
    * @var string
    */
-  public $dataType;
+  public $data_type;
 
 }

--- a/modules/graphql_core/src/Annotation/GraphQLType.php
+++ b/modules/graphql_core/src/Annotation/GraphQLType.php
@@ -19,7 +19,7 @@ class GraphQLType extends GraphQLAnnotationBase {
    *
    * @var string
    */
-  public $dataType;
+  public $data_type;
 
   /**
    * The list of interfaces implemented by this type.

--- a/modules/graphql_core/src/Annotation/GraphQLType.php
+++ b/modules/graphql_core/src/Annotation/GraphQLType.php
@@ -19,7 +19,7 @@ class GraphQLType extends GraphQLAnnotationBase {
    *
    * @var string
    */
-  public $data_type;
+  public $dataType;
 
   /**
    * The list of interfaces implemented by this type.
@@ -29,12 +29,5 @@ class GraphQLType extends GraphQLAnnotationBase {
    * @var array
    */
   public $interfaces = [];
-
-  /**
-   * The fields attached to this type.
-   *
-   * @var array
-   */
-  public $fields = [];
 
 }

--- a/modules/graphql_core/src/GraphQL/Traits/FieldablePluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/FieldablePluginTrait.php
@@ -24,15 +24,8 @@ trait FieldablePluginTrait {
     if ($this instanceof PluginInspectionInterface) {
       $definition = $this->getPluginDefinition();
 
-      $explicitFields = [];
-      if ($definition['fields']) {
-        // Fields that are annotated on the type itself.
-        $explicitFields = $schemaManager->find(function ($field) use ($definition) {
-          return in_array($field['name'], $definition['fields']);
-        }, [GRAPHQL_CORE_FIELD_PLUGIN]);
-      }
-
       $implicitFields = [];
+
       if ($definition['name']) {
         // Fields that are attached by annotating the type on the field.
         $implicitFields = $schemaManager->find(function ($field) use ($definition) {
@@ -42,7 +35,7 @@ trait FieldablePluginTrait {
 
       // Implicit fields have higher precedence than explicit ones.
       // This makes fields overridable.
-      return array_filter($implicitFields + $explicitFields, function ($type) {
+      return array_filter($implicitFields, function ($type) {
         return $type instanceof FieldInterface;
       });
     }

--- a/modules/graphql_core/src/GraphQL/Traits/FieldablePluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/FieldablePluginTrait.php
@@ -27,9 +27,11 @@ trait FieldablePluginTrait {
       $implicitFields = [];
 
       if ($definition['name']) {
+        $types = array_merge([$definition['name']], array_key_exists('interfaces', $definition) ? $definition['interfaces'] : []);
+
         // Fields that are attached by annotating the type on the field.
-        $implicitFields = $schemaManager->find(function ($field) use ($definition) {
-          return in_array($definition['name'], $field['types']);
+        $implicitFields = $schemaManager->find(function ($field) use ($types) {
+          return array_intersect($types, $field['types']);
         }, [GRAPHQL_CORE_FIELD_PLUGIN]);
       }
 

--- a/modules/graphql_core/src/GraphQL/TypePluginBase.php
+++ b/modules/graphql_core/src/GraphQL/TypePluginBase.php
@@ -20,9 +20,7 @@ abstract class TypePluginBase extends AbstractObjectType implements GraphQLPlugi
   use PluginTrait;
   use CacheablePluginTrait;
   use NamedPluginTrait;
-  use FieldablePluginTrait {
-    buildFields as buildAttachedFields;
-  }
+  use FieldablePluginTrait;
 
   /**
    * {@inheritdoc}
@@ -58,14 +56,4 @@ abstract class TypePluginBase extends AbstractObjectType implements GraphQLPlugi
     return [];
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function buildFields(GraphQLSchemaManagerInterface $schemaManager) {
-    $interfaceFields = array_reduce(array_map(function (AbstractInterfaceType $interface) {
-      return $interface->getFields();
-    }, $this->buildInterfaces($schemaManager)), 'array_merge', []);
-    $attachedFields = $this->buildAttachedFields($schemaManager);
-    return array_merge($interfaceFields, $attachedFields);
-  }
 }

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Alias.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Alias.php
@@ -15,7 +15,8 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  * @GraphQLField(
  *   id = "url_alias",
  *   name = "alias",
- *   type = "String"
+ *   type = "String",
+ *   types = {"Url"}
  * )
  */
 class Alias extends Path implements ContainerFactoryPluginInterface {

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQueryCount.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQueryCount.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_query_count",
  *   name = "count",
  *   type = "Int",
+ *   types = {"EntityQueryResult"},
  *   nullable = true
  * )
  */

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQueryEntities.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQueryEntities.php
@@ -18,6 +18,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_query_entities",
  *   name = "entities",
  *   type = "Entity",
+ *   types = {"EntityQueryResult"},
  *   multi = true,
  *   nullable = true
  * )

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityUuid.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityUuid.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "entity_uuid",
  *   name = "entityUuid",
  *   type = "String",
+ *   types = {"Entity"}
  * )
  */
 class EntityUuid extends FieldPluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Path.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Path.php
@@ -12,7 +12,8 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  * @GraphQLField(
  *   id = "url_path",
  *   name = "path",
- *   type = "String"
+ *   type = "String",
+ *   types = {"Url"}
  * )
  */
 class Path extends FieldPluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Routed.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Routed.php
@@ -12,7 +12,8 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  * @GraphQLField(
  *   id = "url_routed",
  *   name = "routed",
- *   type = "Boolean"
+ *   type = "Boolean",
+ *   types = {"Url"}
  * )
  */
 class Routed extends FieldPluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Interfaces/Entity.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Interfaces/Entity.php
@@ -15,10 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @GraphQLInterface(
  *   id = "entity",
- *   name = "Entity",
- *   fields = {
- *     "entityUuid"
- *   }
+ *   name = "Entity"
  * )
  */
 class Entity extends InterfacePluginBase implements ContainerFactoryPluginInterface {

--- a/modules/graphql_core/src/Plugin/GraphQL/Types/EntityQueryResult.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Types/EntityQueryResult.php
@@ -9,8 +9,7 @@ use Drupal\graphql_core\GraphQL\TypePluginBase;
  *
  * @GraphQLType(
  *   id = "entity_query_result",
- *   name = "EntityQueryResult",
- *   fields = {"count", "entities"}
+ *   name = "EntityQueryResult"
  * )
  */
 class EntityQueryResult extends TypePluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Types/UnexposedEntity.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Types/UnexposedEntity.php
@@ -16,8 +16,7 @@ use Drupal\graphql_core\GraphQL\TypePluginBase;
  * @GraphQLType(
  *   id = "unexposed_entity",
  *   name = "UnexposedEntity",
- *   interfaces = {"Entity"},
- *   fields = {"entityUuid"}
+ *   interfaces = {"Entity"}
  * )
  */
 class UnexposedEntity extends TypePluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Types/Url.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Types/Url.php
@@ -9,8 +9,7 @@ use Drupal\graphql_core\GraphQL\TypePluginBase;
  *
  * @GraphQLType(
  *   id = "url",
- *   name = "Url",
- *   fields = {"path", "alias", "routed"}
+ *   name = "Url"
  * )
  */
 class Url extends TypePluginBase {

--- a/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Fields/Type.php
+++ b/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Fields/Type.php
@@ -12,7 +12,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "type",
  *   name = "type",
  *   type = "String",
- *   types = {"Bike", "Car"}
+ *   types = {"Vehicle"}
  * )
  */
 class Type extends FieldPluginBase {

--- a/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Fields/Wheels.php
+++ b/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Fields/Wheels.php
@@ -12,7 +12,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "wheels",
  *   name = "wheels",
  *   type = "Int",
- *   types = {"Car", "Bike"}
+ *   types = {"Vehicle"}
  * )
  */
 class Wheels extends FieldPluginBase {

--- a/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Interfaces/Vehicle.php
+++ b/modules/graphql_core/tests/modules/graphql_plugin_test/src/Plugin/GraphQL/Interfaces/Vehicle.php
@@ -13,8 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @GraphQLInterface(
  *   id = "vehicle",
- *   name = "Vehicle",
- *   fields = {"type", "wheels"}
+ *   name = "Vehicle"
  * )
  */
 class Vehicle extends InterfacePluginBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
Removed the "fields" annotation property from interfaces and types, since it's redundant to the "types" property on field annotations but causes problems with identically named fields on different types.
I would rather stick with one clear way to attach fields to types than inventing something artificial to resolve field name ambiguity. `Type -> Field` has been added as a convenience feature for derived types, but these actually have to implement an interface anyway, and will inherit fields from there.

The one problem left is that this PR creates empty interfaces for entity types, which will freak out GraphiQL. But empty interfaces are another problem I think. I want to keep them, so extensions are able to attach fields to them if necessary, but we have to either attach a fake field (meh), or filter them out in post-processing if they are empty.