### PR TITLE
Fix language enum name

### DIFF
--- a/modules/graphql_content/src/Plugin/GraphQL/Enums/Languages.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Enums/Languages.php
@@ -54,7 +54,7 @@ class Languages extends EnumPluginBase implements ContainerFactoryPluginInterfac
 
     foreach ($this->languageManager->getLanguages() as $language) {
       $values[] = [
-        'name' => $language->getId(),
+        'name' => str_replace('-', '_', $language->getId()),
         'value' => $language->getId(),
       ];
     }

--- a/modules/graphql_content/tests/src/Kernel/EntityByIdTest.php
+++ b/modules/graphql_content/tests/src/Kernel/EntityByIdTest.php
@@ -32,11 +32,18 @@ class EntityByIdTest extends GraphQLFileTestBase {
   ];
 
   /**
-   * The added language.
+   * The added French language.
    *
    * @var string
    */
-  protected $langcode = 'fr';
+  protected $frenchLangcode = 'fr';
+
+  /**
+   * The added Chinese simplified language.
+   *
+   * @var string
+   */
+  protected $chineseSimplifiedLangcode = 'zh-hans';
 
   /**
    * {@inheritdoc}
@@ -53,8 +60,14 @@ class EntityByIdTest extends GraphQLFileTestBase {
       ->grantPermission('access content')
       ->save();
 
-    $language = $this->container->get('entity.manager')->getStorage('configurable_language')->create([
-      'id' => $this->langcode,
+    $language_storage = $this->container->get('entity.manager')->getStorage('configurable_language');
+    $language = $language_storage->create([
+      'id' => $this->frenchLangcode,
+    ]);
+    $language->save();
+
+    $language = $language_storage->create([
+      'id' => $this->chineseSimplifiedLangcode,
     ]);
     $language->save();
   }
@@ -68,7 +81,8 @@ class EntityByIdTest extends GraphQLFileTestBase {
       'type' => 'test',
     ]);
     $node->save();
-    $node->addTranslation($this->langcode, ['title' => 'French node'])->save();
+    $node->addTranslation($this->frenchLangcode, ['title' => 'French node'])->save();
+    $node->addTranslation($this->chineseSimplifiedLangcode, ['title' => 'Chinese simplified node'])->save();
 
     // Check English node.
     $result = $this->executeQueryFile('entity_by_id.gql', [
@@ -83,6 +97,13 @@ class EntityByIdTest extends GraphQLFileTestBase {
       'language' => 'fr',
     ]);
     $this->assertEquals(['entityLabel' => 'French node'], $result['data']['nodeById']);
+
+    // Check Chinese simplified translation.
+    $result = $this->executeQueryFile('entity_by_id.gql', [
+      'id' => $node->id(),
+      'language' => 'zh_hans',
+    ]);
+    $this->assertEquals(['entityLabel' => 'Chinese simplified node'], $result['data']['nodeById']);
   }
 
 }


### PR DESCRIPTION
Some language codes have a hyphen in them, such as `Chinese, Simplified (zh-hans)`, `Portuguese, Brazil (pt-br)`, they are invalid enum names, need to replace the hyphen with a underscore:

* zh-hans --> zh_hans
* pt-br  --> pt_br