### PR TITLE
Language request parameter

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Enums/AvailableLanguages.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Enums/AvailableLanguages.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\graphql_content\Plugin\GraphQL\Enums;
+namespace Drupal\graphql_core\Plugin\GraphQL\Enums;
 
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   name = "AvailableLanguages"
  * )
  */
-class Languages extends EnumPluginBase implements ContainerFactoryPluginInterface {
+class AvailableLanguages extends EnumPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * The language manager.

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/AvailableLanguages.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/AvailableLanguages.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\graphql_core\Plugin\GraphQL\Fields;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+/**
+ * List site-wide configured languages.
+ *
+ * @GraphqlField(
+ *   id = "available_languages_field",
+ *   name = "availableLanguages",
+ *   type = "Language",
+ *   multi = true
+ * )
+ */
+class AvailableLanguages extends FieldPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $pluginId, $pluginDefinition, LanguageManagerInterface $languageManager) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+
+    $this->languageManager = $languageManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveInfo $info) {
+    foreach ($this->languageManager->getLanguages() as $language) {
+      yield $language;
+    }
+  }
+
+}

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/LanguageArgument.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/LanguageArgument.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\graphql_core\Plugin\GraphQL\Fields;
+
+use Drupal\Core\Language\Language;
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+/**
+ * The language enum value.
+ *
+ * @GraphQLField(
+ *   id = "language_argument",
+ *   name = "argument",
+ *   description = "The language id prepared as a language enum value.",
+ *   type = "String",
+ *   types = {"Language"}
+ * )
+ */
+class LanguageArgument extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveInfo $info) {
+    if ($value instanceof Language) {
+      yield str_replace('-', '_', $value->getId());
+    }
+  }
+
+}

--- a/modules/graphql_core/src/Plugin/LanguageNegotiation/LanguageNegotiationGraphQL.php
+++ b/modules/graphql_core/src/Plugin/LanguageNegotiation/LanguageNegotiationGraphQL.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\graphql_core\Plugin\LanguageNegotiation;
+
+use Drupal\language\LanguageNegotiationMethodBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class for identifying language for api calls.
+ *
+ * @LanguageNegotiation(
+ *   id = \Drupal\graphql_core\Plugin\LanguageNegotiation\LanguageNegotiationGraphQL::METHOD_ID,
+ *   weight = -10,
+ *   name = @Translation("GraphQL API"),
+ *   description = @Translation("Language for GraphQL API based on get parameter."),
+ * )
+ */
+class LanguageNegotiationGraphQL extends LanguageNegotiationMethodBase {
+
+  /**
+   * The language negotiation method id.
+   */
+  const METHOD_ID = 'language-graphql';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLangcode(Request $request = NULL) {
+    $langcode = NULL;
+
+    if ($this->languageManager && $request && $request->query->has('graphqlLanguage')) {
+      $langcode = $request->query->get('graphqlLanguage');
+    }
+
+    return $langcode;
+  }
+
+}

--- a/modules/graphql_core/tests/queries/language_parameter.gql
+++ b/modules/graphql_core/tests/queries/language_parameter.gql
@@ -1,0 +1,18 @@
+query {
+  default:route(path: "/graphql") {
+    ... LanguageFragment
+  }
+}
+
+fragment LanguageFragment on Url {
+  languageInterfaceContext {
+    ... on Language {
+      id
+      name
+      isDefault
+      isLocked
+      direction
+      weight
+    }
+  }
+}

--- a/modules/graphql_core/tests/queries/languages.gql
+++ b/modules/graphql_core/tests/queries/languages.gql
@@ -1,4 +1,13 @@
 query {
+  languages:availableLanguages {
+    id
+    name
+    isDefault
+    isLocked
+    direction
+    weight
+  }
+
   default:route(path: "/graphql/test/a") {
     ... LanguageFragment
   }

--- a/modules/graphql_core/tests/queries/languages.gql
+++ b/modules/graphql_core/tests/queries/languages.gql
@@ -6,6 +6,7 @@ query {
     isLocked
     direction
     weight
+    argument
   }
 
   default:route(path: "/graphql/test/a") {

--- a/modules/graphql_core/tests/src/Kernel/LanguageParameterTest.php
+++ b/modules/graphql_core/tests/src/Kernel/LanguageParameterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\Tests\graphql_core\Kernel;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Tests\graphql\Functional\QueryTestBase;
+use Drupal\Tests\graphql_core\Traits\GraphQLFileTestTrait;
+
+/**
+ * Test multilingual behavior of `graphql_core` features.
+ *
+ * @group graphql_core
+ */
+class LanguageParameterTest extends QueryTestBase {
+  use GraphQLFileTestTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'language',
+    'graphql',
+    'graphql_core',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $user = $this->drupalCreateUser([
+      'administer languages',
+      'access administration pages',
+      'view the administration theme',
+      'execute graphql requests',
+    ]);
+
+    $this->drupalLogin($user);
+
+    $this->drupalPostForm('admin/config/regional/language/add', ['predefined_langcode' => 'fr'], $this->t('Add language'));
+    $this->drupalPostForm('admin/config/regional/language/detection', ['language_interface[enabled][language-graphql]' => 1], $this->t('Save settings'));
+  }
+
+  /**
+   * Test if the language parameter is picked up correctly.
+   */
+  public function testLanguageParameter() {
+    $default = json_decode($this->query($this->getQuery('language_parameter.gql')), TRUE);
+    $parameterized = json_decode($this->query($this->getQuery('language_parameter.gql'), NULL, NULL, ['graphqlLanguage' => 'fr']), TRUE);
+
+    $this->assertEquals([
+      'id' => 'en',
+      'name' => 'English',
+      'isDefault' => TRUE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 0,
+    ], $default['data']['default']['languageInterfaceContext'], 'Default language is correct.');
+
+    $this->assertEquals([
+      'id' => 'fr',
+      'name' => 'French',
+      'isDefault' => FALSE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 1,
+    ], $parameterized['data']['default']['languageInterfaceContext'], 'Requested language is correct.');
+  }
+
+}

--- a/modules/graphql_core/tests/src/Kernel/LanguageTest.php
+++ b/modules/graphql_core/tests/src/Kernel/LanguageTest.php
@@ -35,9 +35,15 @@ class LanguageTest extends LanguageTestBase {
       'id' => 'fr',
       'weight' => 1,
     ])->save();
+
     ConfigurableLanguage::create([
       'id' => 'es',
       'weight' => 2,
+    ])->save();
+
+    ConfigurableLanguage::create([
+      'id' => 'pt-br',
+      'weight' => 3,
     ])->save();
 
     $config = $this->config('language.negotiation');
@@ -89,6 +95,7 @@ class LanguageTest extends LanguageTestBase {
       'isLocked' => FALSE,
       'direction' => 'ltr',
       'weight' => 0,
+      'argument' => 'en',
     ];
 
     $french = [
@@ -98,6 +105,7 @@ class LanguageTest extends LanguageTestBase {
       'isLocked' => FALSE,
       'direction' => 'ltr',
       'weight' => 1,
+      'argument' => 'fr',
     ];
 
     $spanish = [
@@ -107,9 +115,20 @@ class LanguageTest extends LanguageTestBase {
       'isLocked' => FALSE,
       'direction' => 'ltr',
       'weight' => 2,
+      'argument' => 'es',
     ];
 
-    $this->assertEquals([$english, $french, $spanish], $result['data']['languages']);
+    $brazil = [
+      'id' => 'pt-br',
+      'name' => 'Portuguese, Brazil',
+      'isDefault' => FALSE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 3,
+      'argument' => 'pt_br',
+    ];
+
+    $this->assertEquals([$english, $french, $spanish, $brazil], $result['data']['languages']);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/LanguageTest.php
+++ b/modules/graphql_core/tests/src/Kernel/LanguageTest.php
@@ -31,8 +31,14 @@ class LanguageTest extends LanguageTestBase {
     $this->installEntitySchema('configurable_language');
     $this->container->get('router.builder')->rebuild();
 
-    ConfigurableLanguage::create(['id' => 'es'])->save();
-    ConfigurableLanguage::create(['id' => 'fr'])->save();
+    ConfigurableLanguage::create([
+      'id' => 'fr',
+      'weight' => 1,
+    ])->save();
+    ConfigurableLanguage::create([
+      'id' => 'es',
+      'weight' => 2,
+    ])->save();
 
     $config = $this->config('language.negotiation');
     $config->set('url.prefixes', ['en' => 'en', 'es' => 'es', 'fr' => 'fr'])
@@ -62,12 +68,48 @@ class LanguageTest extends LanguageTestBase {
       'isDefault' => FALSE,
       'isLocked' => FALSE,
       'direction' => 'ltr',
-      'weight' => 0,
+      'weight' => 1,
     ];
 
     $this->assertEquals($english, $result['data']['default']['languageInterfaceContext']);
     $this->assertEquals($english, $result['data']['en']['languageInterfaceContext']);
     $this->assertEquals($french, $result['data']['fr']['languageInterfaceContext']);
+  }
+
+  /**
+   * Test listing of available languages.
+   */
+  public function testAvailableLanguages() {
+    $result = $this->executeQueryFile('languages.gql');
+
+    $english = [
+      'id' => 'en',
+      'name' => 'English',
+      'isDefault' => TRUE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 0,
+    ];
+
+    $french = [
+      'id' => 'fr',
+      'name' => 'French',
+      'isDefault' => FALSE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 1,
+    ];
+
+    $spanish = [
+      'id' => 'es',
+      'name' => 'Spanish',
+      'isDefault' => FALSE,
+      'isLocked' => FALSE,
+      'direction' => 'ltr',
+      'weight' => 2,
+    ];
+
+    $this->assertEquals([$english, $french, $spanish], $result['data']['languages']);
   }
 
 }

--- a/tests/src/Functional/QueryTestBase.php
+++ b/tests/src/Functional/QueryTestBase.php
@@ -41,11 +41,12 @@ abstract class QueryTestBase extends BrowserTestBase {
    * @param $query
    * @param array $variables
    * @param string|null $operation
+   * @param string[] $parameters
    *
    * @return string The content returned from the request.
    * The content returned from the request.
    */
-  protected function query($query, array $variables = NULL, $operation = NULL) {
+  protected function query($query, array $variables = NULL, $operation = NULL, $parameters = []) {
     $body = [
       'query' => $query,
       'variables' => $variables,
@@ -66,6 +67,7 @@ abstract class QueryTestBase extends BrowserTestBase {
     $response = \Drupal::httpClient()->post($this->getAbsoluteUrl($this->queryUrl), [
       'body' => json_encode($body),
       'cookies' => $jar,
+      'query' => $parameters,
     ]);
 
     return (string) $response->getBody();


### PR DESCRIPTION
Introduces a language negotiation plugin that can be used to set the default language for a GraphQL query on a request basis.

```
/graphql?graphqlLanguage=de
```

Also exposes available languages on a dedicated root field, for building language switchers.