### PR TITLE
Casting all return types for image width/height fields.

### DIFF
--- a/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageResourceHeight.php
+++ b/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageResourceHeight.php
@@ -27,7 +27,7 @@ class ImageResourceHeight extends FieldPluginBase {
       yield (int) $value->height;
     }
     if (is_array($value) && array_key_exists('height', $value)) {
-      yield $value['height'];
+      yield (int) $value['height'];
     }
   }
 

--- a/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageResourceWidth.php
+++ b/modules/graphql_image/src/Plugin/GraphQL/Fields/ImageResourceWidth.php
@@ -27,7 +27,7 @@ class ImageResourceWidth extends FieldPluginBase {
       yield (int) $value->width;
     }
     if (is_array($value) && array_key_exists('width', $value)) {
-      yield $value['width'];
+      yield (int) $value['width'];
     }
   }
 


### PR DESCRIPTION
Breaks with "not matching datatype" when not casted.