### PR TITLE
Call processInbound() in the DenyUnsafeMethodUnlessQuery request policy.

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -104,7 +104,7 @@ services:
       - { name: graphql_request_policy }
   graphql.request_policy.deny_unsafe_method_unless_query:
     class: Drupal\graphql\Cache\RequestPolicy\DenyUnsafeMethodUnlessQuery
-    arguments: ['@current_route_match']
+    arguments: ['@path_processor_manager']
     tags:
       - { name: graphql_request_policy }
   graphql.response_policy.deny_mutation:

--- a/src/Cache/RequestPolicy/DenyUnsafeMethodUnlessQuery.php
+++ b/src/Cache/RequestPolicy/DenyUnsafeMethodUnlessQuery.php
@@ -3,6 +3,7 @@
 namespace Drupal\graphql\Cache\RequestPolicy;
 
 use Drupal\Core\PageCache\RequestPolicyInterface;
+use Drupal\Core\PathProcessor\PathProcessorManager;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -11,10 +12,21 @@ use Symfony\Component\HttpFoundation\Request;
 class DenyUnsafeMethodUnlessQuery implements RequestPolicyInterface {
 
   /**
+   * A path processor manager.
+   *
+   * @var \Drupal\Core\PathProcessor\PathProcessorManager
+   */
+  protected $pathProcessor;
+
+  public function __construct(PathProcessorManager $pathProcessor) {
+    $this->pathProcessor = $pathProcessor;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function check(Request $request) {
-    if (!$request->isMethodSafe() && !($request->getMethod() === 'POST' && $request->getPathInfo() === '/graphql')) {
+    if (!$request->isMethodSafe() && !($request->getMethod() === 'POST' && $this->pathProcessor->processInbound($request->getPathInfo(), $request) === '/graphql')) {
       return static::DENY;
     }
 


### PR DESCRIPTION
This should fix the issue that, when using a path prefix for calling the API, like a language prefix, the response is not cached.