### PR TITLE
Enum types should always be named

### DIFF
--- a/modules/graphql_core/src/GraphQL/InputTypePluginBase.php
+++ b/modules/graphql_core/src/GraphQL/InputTypePluginBase.php
@@ -107,7 +107,7 @@ abstract class InputTypePluginBase extends AbstractInputObjectType implements Gr
     else {
       $typeInfo = is_array($field) ? $field['type'] : $field;
 
-      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo) : $schemaManager->findByName($typeInfo, [
+      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $field['name']) : $schemaManager->findByName($typeInfo, [
         GRAPHQL_CORE_INPUT_TYPE_PLUGIN,
         GRAPHQL_CORE_SCALAR_PLUGIN,
         GRAPHQL_CORE_ENUM_PLUGIN,

--- a/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
@@ -78,7 +78,7 @@ trait ArgumentAwarePluginTrait {
     else {
       $typeInfo = is_array($argument) ? $argument['type'] : $argument;
 
-      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo) : $schemaManager->findByName($typeInfo, [
+      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $argument['name']) : $schemaManager->findByName($typeInfo, [
         GRAPHQL_CORE_INPUT_TYPE_PLUGIN,
         GRAPHQL_CORE_SCALAR_PLUGIN,
         GRAPHQL_CORE_ENUM_PLUGIN,

--- a/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
@@ -44,11 +44,13 @@ trait TypedPluginTrait {
    *
    * @param string[] $options
    *   A list of options.
+   * @param string $parentName
+   *   A base name for generating name for the enum type.
    *
    * @return EnumType
    *   The enumeration type.
    */
-  protected function buildEnumConfig(array $options) {
+  protected function buildEnumConfig(array $options, $parentName) {
     $values = [];
     foreach ($options as $value => $description) {
       $values[] = [
@@ -57,7 +59,10 @@ trait TypedPluginTrait {
         'description' => $description,
       ];
     }
-    return new EnumType(['values' => $values]);
+    return new EnumType([
+      'name' => graphql_core_camelcase([$parentName, 'Enum']),
+      'values' => $values,
+    ]);
   }
 
   /**
@@ -85,7 +90,7 @@ trait TypedPluginTrait {
         $type = array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
       }
       else if (array_key_exists('type', $definition) && $definition['type']) {
-        $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type']) : $schemaManager->findByName($definition['type'], [
+        $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type'], $definition['name']) : $schemaManager->findByName($definition['type'], [
           GRAPHQL_CORE_SCALAR_PLUGIN,
           GRAPHQL_CORE_TYPE_PLUGIN,
           GRAPHQL_CORE_INTERFACE_PLUGIN,

--- a/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Character.php
+++ b/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Character.php
@@ -18,6 +18,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   },
  *   arguments = {
  *     "character" = {
+ *       "name" = "character",
  *       "type" = {
  *         "a" = "Alpha",
  *         "b" = "Beta",

--- a/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Characters.php
+++ b/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Characters.php
@@ -19,6 +19,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   },
  *   arguments = {
  *     "characters" = {
+ *       "name" = "characters",
  *       "multi" = true,
  *       "type" = {
  *         "a" = "Alpha",

--- a/modules/graphql_core/tests/src/Kernel/EnumTest.php
+++ b/modules/graphql_core/tests/src/Kernel/EnumTest.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\Tests\graphql_core\Kernel;
 
+use Drupal\graphql\GraphQL\TypeCollector;
+use Youshido\GraphQL\Type\Enum\EnumType;
+
 /**
  * Test enumeration support in different ways.
  *
@@ -39,6 +42,20 @@ class EnumTest extends GraphQLFileTestBase {
         'A', 'B', 'C',
       ],
     ], $result['data'], 'Annotated enums accept and return properly.');
+  }
+
+  /**
+   * Test enum type names.
+   */
+  public function testEnumTypeNames() {
+    /** @var \Youshido\GraphQL\Schema\AbstractSchema $schema */
+    $schema = \Drupal::service('graphql.schema');
+    $types = TypeCollector::collectTypes($schema);
+    foreach ($types as $type) {
+      if ($type instanceof EnumType && $type->getName() === NULL) {
+        $this->fail('Unnamed enum type found.');
+      }
+    }
   }
 
 }

--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -57,6 +57,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
       if ($sorts) {
         $arguments += [
           'sortDirection' => [
+            "name" => "sortDirection",
             "type" => [
               "ASC" => "Ascending",
               "DESC" => "Descending",
@@ -64,6 +65,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
             "default" => TRUE,
           ],
           'sortBy' => [
+            "name" => "sortBy",
             "type" => array_map(function ($sort) {
               return $sort['expose']['label'];
             }, $sorts),


### PR DESCRIPTION
During work on #136 I noticed that schema is broken as soon as I add an exposed filter to a GraphQL view.

A particular error was: `Invalid or incomplete schema, unknown type: AvailableLanguages.`
(But I worked on an existing project, not on a clean Drupal installation)

When I checked schema, I found that AvailableLanguages type is actually missing from the schema as well as many other type.
<img width="1384" alt="screen_shot_2017-07-01_at_15_48_29" src="https://user-images.githubusercontent.com/989015/27762231-abe4fbec-5e76-11e7-9a32-2049e4266af9.png">

My best guess is that types should always have names.