### PR TITLE
Support for offset pagination in views.

### DIFF
--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -113,6 +113,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
         $paged = TRUE;
         $arguments += [
           'page' => ['type' => 'Int', 'default' => $this->getPagerOffset($display)],
+          'offset' => ['type' => 'Int', 'default' => $this->getPagerOffset($display)],
           'pageSize' => ['type' => 'Int', 'default' => $this->getPagerLimit($display)],
         ];
       }

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -110,7 +110,12 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       if ($definition['paged']) {
         // Set paging parameters.
         $executable->setItemsPerPage($args['pageSize']);
-        $executable->setCurrentPage($args['page']);
+        if (isset($args['offset'])) {
+          $executable->setOffset($args['offset']);
+        }
+        else {
+          $executable->setCurrentPage($args['page']);
+        }
         $executable->execute();
         yield $executable;
       }

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -110,7 +110,7 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       if ($definition['paged']) {
         // Set paging parameters.
         $executable->setItemsPerPage($args['pageSize']);
-        if (isset($args['offset'])) {
+        if (!empty($args['offset'])) {
           $executable->setOffset($args['offset']);
         }
         else {


### PR DESCRIPTION
Sometimes it is easier to specify on offset when getting the next page, instead of computing the next page based on the current number of results and the number of items per page, as in the example here: http://dev.apollodata.com/react/pagination.html#numbered-pages