### PR TITLE
Use a proper url for the batch subrequests to /graphql.

### DIFF
--- a/src/Controller/RequestController.php
+++ b/src/Controller/RequestController.php
@@ -11,6 +11,7 @@ use Drupal\Core\Config\Config;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Url;
 use Drupal\graphql\GraphQL\Execution\Processor;
 use Drupal\graphql\Reducers\ReducerManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -157,9 +158,10 @@ class RequestController implements ContainerInjectionInterface {
       $parameters = array_merge($requestParameters, $query);
       $content = $method === 'POST' ? array_merge($query, $requestContent) : FALSE;
       $content = $content ? json_encode($content) : '';
+      $graphql_url = Url::fromUri('internal:/graphql')->toString(TRUE)->getGeneratedUrl();
 
       $subRequest = Request::create(
-        '/graphql',
+        $graphql_url,
         $method,
         $parameters,
         $request->cookies->all(),

--- a/src/Controller/RequestController.php
+++ b/src/Controller/RequestController.php
@@ -158,10 +158,10 @@ class RequestController implements ContainerInjectionInterface {
       $parameters = array_merge($requestParameters, $query);
       $content = $method === 'POST' ? array_merge($query, $requestContent) : FALSE;
       $content = $content ? json_encode($content) : '';
-      $graphql_url = Url::fromUri('internal:/graphql')->toString(TRUE)->getGeneratedUrl();
+      $graphqlUrl = Url::fromUri('internal:/graphql')->toString(TRUE)->getGeneratedUrl();
 
       $subRequest = Request::create(
-        $graphql_url,
+        $graphqlUrl,
         $method,
         $parameters,
         $request->cookies->all(),


### PR DESCRIPTION
For example, when having a language prefix (so the original request is to /de/graphql), the subrequest should still keep that prefix. This did not happen till now, the language prefix was lost in the subrequests.