### PR TITLE
More specific name for view sorts

### DIFF
--- a/modules/graphql_core/src/Annotation/GraphQLField.php
+++ b/modules/graphql_core/src/Annotation/GraphQLField.php
@@ -28,7 +28,11 @@ class GraphQLField extends GraphQLAnnotationBase  {
    *
    * Must be a registered Interface, Type, Scalar or Enum.
    *
-   * @var string
+   * If an associative array is provided - the Enum type will be created
+   * automatically for the given set of values. But $enum_type_name has to be
+   * defined in this case.
+   *
+   * @var string|array
    */
   public $type = NULL;
 
@@ -58,5 +62,14 @@ class GraphQLField extends GraphQLAnnotationBase  {
    * @var array
    */
   public $arguments = [];
+
+  /**
+   * The name for the Enum type.
+   *
+   * Only required if $type is provided as an associative array.
+   *
+   * @var string|null
+   */
+  public $enum_type_name = NULL;
 
 }

--- a/modules/graphql_core/src/GraphQL/InputTypePluginBase.php
+++ b/modules/graphql_core/src/GraphQL/InputTypePluginBase.php
@@ -107,7 +107,7 @@ abstract class InputTypePluginBase extends AbstractInputObjectType implements Gr
     else {
       $typeInfo = is_array($field) ? $field['type'] : $field;
 
-      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $field['name']) : $schemaManager->findByName($typeInfo, [
+      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $field['enum_type_name']) : $schemaManager->findByName($typeInfo, [
         GRAPHQL_CORE_INPUT_TYPE_PLUGIN,
         GRAPHQL_CORE_SCALAR_PLUGIN,
         GRAPHQL_CORE_ENUM_PLUGIN,

--- a/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
@@ -78,7 +78,7 @@ trait ArgumentAwarePluginTrait {
     else {
       $typeInfo = is_array($argument) ? $argument['type'] : $argument;
 
-      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $argument['name']) : $schemaManager->findByName($typeInfo, [
+      $type = is_array($typeInfo) ? $this->buildEnumConfig($typeInfo, $argument['enum_type_name']) : $schemaManager->findByName($typeInfo, [
         GRAPHQL_CORE_INPUT_TYPE_PLUGIN,
         GRAPHQL_CORE_SCALAR_PLUGIN,
         GRAPHQL_CORE_ENUM_PLUGIN,

--- a/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
@@ -44,13 +44,13 @@ trait TypedPluginTrait {
    *
    * @param string[] $options
    *   A list of options.
-   * @param string $parentName
-   *   A base name for generating name for the enum type.
+   * @param string $typeName
+   *   The name for the enum type.
    *
    * @return EnumType
    *   The enumeration type.
    */
-  protected function buildEnumConfig(array $options, $parentName) {
+  protected function buildEnumConfig(array $options, $typeName) {
     $values = [];
     foreach ($options as $value => $description) {
       $values[] = [
@@ -60,7 +60,7 @@ trait TypedPluginTrait {
       ];
     }
     return new EnumType([
-      'name' => graphql_core_camelcase([$parentName, 'Enum']),
+      'name' => $typeName,
       'values' => $values,
     ]);
   }
@@ -90,7 +90,10 @@ trait TypedPluginTrait {
         $type = array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
       }
       else if (array_key_exists('type', $definition) && $definition['type']) {
-        $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type'], $definition['name']) : $schemaManager->findByName($definition['type'], [
+        if (is_array($definition['type']) && !isset($definition['enum_type_name'])) {
+          var_dump($definition);
+        }
+        $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type'], $definition['enum_type_name']) : $schemaManager->findByName($definition['type'], [
           GRAPHQL_CORE_SCALAR_PLUGIN,
           GRAPHQL_CORE_TYPE_PLUGIN,
           GRAPHQL_CORE_INTERFACE_PLUGIN,

--- a/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
@@ -90,9 +90,6 @@ trait TypedPluginTrait {
         $type = array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
       }
       else if (array_key_exists('type', $definition) && $definition['type']) {
-        if (is_array($definition['type']) && !isset($definition['enum_type_name'])) {
-          var_dump($definition);
-        }
         $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type'], $definition['enum_type_name']) : $schemaManager->findByName($definition['type'], [
           GRAPHQL_CORE_SCALAR_PLUGIN,
           GRAPHQL_CORE_TYPE_PLUGIN,

--- a/modules/graphql_core/src/GraphQLSchemaManager.php
+++ b/modules/graphql_core/src/GraphQLSchemaManager.php
@@ -54,9 +54,6 @@ class GraphQLSchemaManager implements GraphQLSchemaManagerInterface {
   public function find(callable $selector, array $types, $invert = FALSE) {
     $instances = [];
     foreach ($this->getDefinitions() as $index => $def) {
-      if (!isset($def['definition']['name'])) {
-        var_dump($def['definition']);
-      }
       $name = $def['definition']['name'];
       if (!$name) {
         throw new \Exception("Invalid GraphQL plugin definition. No name defined.");

--- a/modules/graphql_core/src/GraphQLSchemaManager.php
+++ b/modules/graphql_core/src/GraphQLSchemaManager.php
@@ -54,6 +54,9 @@ class GraphQLSchemaManager implements GraphQLSchemaManagerInterface {
   public function find(callable $selector, array $types, $invert = FALSE) {
     $instances = [];
     foreach ($this->getDefinitions() as $index => $def) {
+      if (!isset($def['definition']['name'])) {
+        var_dump($def['definition']);
+      }
       $name = $def['definition']['name'];
       if (!$name) {
         throw new \Exception("Invalid GraphQL plugin definition. No name defined.");

--- a/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Character.php
+++ b/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Character.php
@@ -11,6 +11,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  * @GraphQLField(
  *   id = "character",
  *   name = "character",
+ *   enum_type_name = "CharacterEnum",
  *   type = {
  *     "a" = "Alpha",
  *     "b" = "Beta",
@@ -18,7 +19,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   },
  *   arguments = {
  *     "character" = {
- *       "name" = "character",
+ *       "enum_type_name" = "CharacterEnum",
  *       "type" = {
  *         "a" = "Alpha",
  *         "b" = "Beta",

--- a/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Characters.php
+++ b/modules/graphql_core/tests/modules/graphql_enum_test/src/Plugin/GraphQL/Fields/Characters.php
@@ -12,6 +12,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "characters",
  *   name = "characters",
  *   multi = true,
+ *   enum_type_name = "CharactersEnum",
  *   type = {
  *     "a" = "Alpha",
  *     "b" = "Beta",
@@ -19,7 +20,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   },
  *   arguments = {
  *     "characters" = {
- *       "name" = "characters",
+ *       "enum_type_name" = "CharactersEnum",
  *       "multi" = true,
  *       "type" = {
  *         "a" = "Alpha",

--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -90,7 +90,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
             "default" => TRUE,
           ],
           'sortBy' => [
-            "name" => "sortBy",
+            "name" => graphql_core_propcase([$id, 'SortBy']),
             "type" => array_map(function ($sort) {
               return $sort['expose']['label'];
             }, $sorts),

--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -82,7 +82,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
       if ($sorts) {
         $arguments += [
           'sortDirection' => [
-            "name" => "sortDirection",
+            "enum_type_name" => "ViewsSortDirectionEnum",
             "type" => [
               "ASC" => "Ascending",
               "DESC" => "Descending",
@@ -90,7 +90,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
             "default" => TRUE,
           ],
           'sortBy' => [
-            "name" => graphql_core_propcase([$id, 'SortBy']),
+            "enum_type_name" => graphql_core_camelcase([$id, 'SortByEnum']),
             "type" => array_map(function ($sort) {
               return $sort['expose']['label'];
             }, $sorts),

--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -90,7 +90,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
             "default" => TRUE,
           ],
           'sortBy' => [
-            "enum_type_name" => graphql_core_camelcase([$id, 'SortByEnum']),
+            "enum_type_name" => graphql_core_camelcase(['SortBy', $id, 'Enum']),
             "type" => array_map(function ($sort) {
               return $sort['expose']['label'];
             }, $sorts),


### PR DESCRIPTION
The "name" key is used as a base name for creating the name of the enum type. So it should be pretty specific.