### PR TITLE
Fix for taxonomy term views filters

### DIFF
--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -106,6 +106,11 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       }
 
       $executable->setExposedInput($input);
+      // This is a workaround for the Taxonomy Term filter which requires a full
+      // exposed form to be sent OR the display being an attachment to just
+      // accept input values.
+      $executable->is_attachment = TRUE;
+      $executable->exposed_raw_input = $input;
 
       if ($definition['paged']) {
         // Set paging parameters.

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -101,8 +101,12 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       // If some filters are missing from the input, set them to an empty string
       // explicitly. Otherwise views module generates "Undefined index" notice.
       $filters = $executable->getDisplay()->getOption('filters');
-      foreach (array_keys($filters) as $filter) {
-        $input[$filter] = isset($args['filter'][$filter]) ? $args['filter'][$filter] : '';
+      foreach ($filters as $filterKey => $filterRow) {
+        if (!isset($args['filter'][$filterKey])) {
+          $input[$filterKey] = $filterRow['value'];
+        } else {
+          $input[$filterKey] = $args['filter'][$filterKey];
+        }
       }
 
       $executable->setExposedInput($input);

--- a/modules/graphql_views/tests/modules/graphql_views_test/config/install/views.view.graphql_test.yml
+++ b/modules/graphql_views/tests/modules/graphql_views_test/config/install/views.view.graphql_test.yml
@@ -3,9 +3,11 @@ status: true
 dependencies:
   config:
     - node.type.test
+    - taxonomy.vocabulary.tags
   module:
     - graphql_views
     - node
+    - taxonomy
     - user
 id: graphql_test
 label: 'GraphQL Test'
@@ -168,6 +170,51 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: string
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: Tags
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: tags
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
@@ -200,6 +247,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -257,6 +305,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -356,6 +405,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -418,6 +468,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -479,6 +530,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -504,6 +556,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -543,6 +596,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -565,6 +619,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -620,6 +675,7 @@ display:
         - url
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/graphql_views/tests/modules/graphql_views_test/graphql_views_test.info.yml
+++ b/modules/graphql_views/tests/modules/graphql_views_test/graphql_views_test.info.yml
@@ -5,5 +5,6 @@ core: 8.x
 dependencies:
   - graphql_views
   - node
+  - taxonomy
   - user
   - views

--- a/modules/graphql_views/tests/queries/filtered.gql
+++ b/modules/graphql_views/tests/queries/filtered.gql
@@ -4,4 +4,8 @@
     entityLabel
   }
 
+  multi:graphqlTestFilteredView (filter: {field_tags_target_id: ["1", "2"]}) {
+    entityLabel
+  }
+
 }

--- a/modules/graphql_views/tests/src/Kernel/ViewsTest.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTest.php
@@ -104,12 +104,25 @@ class ViewsTest extends ViewsTestBase {
   public function testFilteredView() {
     $result = $this->executeQueryFile('filtered.gql');
     $this->assertEquals([
-      'default' => [
-        ['entityLabel' => 'Node A'],
-        ['entityLabel' => 'Node A'],
-        ['entityLabel' => 'Node A'],
-      ],
-    ], $result['data'], 'Filtering works as expected.');
+      ['entityLabel' => 'Node A'],
+      ['entityLabel' => 'Node A'],
+      ['entityLabel' => 'Node A'],
+    ], $result['data']['default'], 'Filtering works as expected.');
+  }
+
+  /**
+   * Test filter behavior.
+   */
+  public function testMultiValueFilteredView() {
+    $result = $this->executeQueryFile('filtered.gql');
+    $this->assertEquals([
+      ['entityLabel' => 'Node A'],
+      ['entityLabel' => 'Node B'],
+      ['entityLabel' => 'Node A'],
+      ['entityLabel' => 'Node B'],
+      ['entityLabel' => 'Node A'],
+      ['entityLabel' => 'Node B'],
+    ], $result['data']['multi'], 'Filtering works as expected.');
   }
 
 }

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
@@ -7,8 +7,7 @@ use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
-use Drupal\taxonomy\Tests\TaxonomyTestTrait;
-use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
+
 use Drupal\user\Entity\Role;
 
 /**
@@ -16,11 +15,10 @@ use Drupal\user\Entity\Role;
  *
  * @group graphql_views
  */
-abstract class ViewsTestBase extends GraphQLFileTestBase {
+abstract class ViewsTestBase extends ViewsTestBaseDeprecationFix {
   use NodeCreationTrait;
   use ContentTypeCreationTrait;
   use EntityReferenceTestTrait;
-  use TaxonomyTestTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
@@ -7,7 +7,7 @@ use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
-use Drupal\Tests\taxonomy\Functional\TaxonomyTestTrait;
+use Drupal\taxonomy\Tests\TaxonomyTestTrait;
 use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
 use Drupal\user\Entity\Role;
 

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
@@ -7,7 +7,7 @@ use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
-use Drupal\taxonomy\Tests\TaxonomyTestTrait;
+use Drupal\Tests\taxonomy\Functional\TaxonomyTestTrait;
 use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
 use Drupal\user\Entity\Role;
 

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
@@ -7,7 +7,6 @@ use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
-
 use Drupal\user\Entity\Role;
 
 /**

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBase.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\Tests\graphql_views\Kernel;
 
+use Drupal\field\Tests\EntityReference\EntityReferenceTestTrait;
 use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\Tests\TaxonomyTestTrait;
 use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
 use Drupal\user\Entity\Role;
 
@@ -15,6 +19,8 @@ use Drupal\user\Entity\Role;
 abstract class ViewsTestBase extends GraphQLFileTestBase {
   use NodeCreationTrait;
   use ContentTypeCreationTrait;
+  use EntityReferenceTestTrait;
+  use TaxonomyTestTrait;
 
   /**
    * {@inheritdoc}
@@ -25,6 +31,7 @@ abstract class ViewsTestBase extends GraphQLFileTestBase {
     'filter',
     'text',
     'views',
+    'taxonomy',
     'graphql_content',
     'graphql_views',
     'graphql_views_test',
@@ -44,18 +51,46 @@ abstract class ViewsTestBase extends GraphQLFileTestBase {
     parent::setUp();
     $this->installEntitySchema('node');
     $this->installEntitySchema('view');
+    $this->installEntitySchema('taxonomy_term');
     $this->installConfig(['node', 'filter', 'views', 'graphql_views_test']);
     $this->installSchema('node', 'node_access');
     $this->createContentType(['type' => 'test']);
+    $this->createEntityReferenceField('node', 'test', 'field_tags', 'Tags', 'taxonomy_term');
+
+    Vocabulary::create([
+      'name' => 'Tags',
+      'vid' => 'tags',
+    ])->save();
 
     Role::load('anonymous')
       ->grantPermission('access content')
       ->save();
 
+    $terms = [];
+
+    $terms['A'] = Term::create([
+      'name' => 'Term A',
+      'vid' => 'tags',
+    ]);
+    $terms['A']->save();
+
+    $terms['B'] = Term::create([
+      'name' => 'Term B',
+      'vid' => 'tags',
+    ]);
+    $terms['B']->save();
+
+    $terms['C'] = Term::create([
+      'name' => 'Term C',
+      'vid' => 'tags',
+    ]);
+    $terms['C']->save();
+
     foreach ($this->letters as $index => $letter) {
       $this->createNode([
         'title' => 'Node ' . $letter,
         'type' => 'test',
+        'field_tags' => $terms[$letter],
       ])->save();
     }
   }

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBaseDeprecationFix.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBaseDeprecationFix.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\Tests\graphql_views\Kernel;
+
+use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
+
+
+if (version_compare(\Drupal::VERSION, '8.4', '<')) {
+  abstract class ViewsTestBaseDeprecationFix extends GraphQLFileTestBase {
+    use \Drupal\taxonomy\Tests\TaxonomyTestTrait;
+  }
+
+} else {
+
+  abstract class ViewsTestBaseDeprecationFix extends GraphQLFileTestBase {
+    use \Drupal\Tests\taxonomy\Functional\TaxonomyTestTrait;
+  }
+}

--- a/modules/graphql_views/tests/src/Kernel/ViewsTestBaseDeprecationFix.php
+++ b/modules/graphql_views/tests/src/Kernel/ViewsTestBaseDeprecationFix.php
@@ -4,14 +4,11 @@ namespace Drupal\Tests\graphql_views\Kernel;
 
 use Drupal\Tests\graphql_core\Kernel\GraphQLFileTestBase;
 
-
 if (version_compare(\Drupal::VERSION, '8.4', '<')) {
   abstract class ViewsTestBaseDeprecationFix extends GraphQLFileTestBase {
     use \Drupal\taxonomy\Tests\TaxonomyTestTrait;
   }
-
 } else {
-
   abstract class ViewsTestBaseDeprecationFix extends GraphQLFileTestBase {
     use \Drupal\Tests\taxonomy\Functional\TaxonomyTestTrait;
   }


### PR DESCRIPTION
What first seemed to be a problem with multi-value fields in views filters turned out to be an issue with some views filters only working properly if an actual exposed form is being submitted ([TaxonomyIndexTid](https://github.com/drupal/drupal/blob/8.4.x/core/modules/taxonomy/src/Plugin/views/filter/TaxonomyIndexTid.php)).

I was able to work around by marking the views as attachment, which causes the filter to skip validation but I'm all ears for better solutions.

