### PR TITLE
Use the cache tags of the executable view instead of the view entity for the View field.

### DIFF
--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -128,7 +128,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
         'view' => $viewId,
         'display' => $displayId,
         'paged' => $paged,
-        'cache_tags' => $view->getCacheTags(),
+        'cache_tags' => $view->getExecutable()->getCacheTags(),
         'cache_contexts' => $view->getCacheContexts(),
         'cache_max_age' => $view->getCacheMaxAge(),
       ] + $basePluginDefinition;

--- a/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
+++ b/modules/graphql_views/src/Plugin/Deriver/ViewDeriver.php
@@ -128,7 +128,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
         'view' => $viewId,
         'display' => $displayId,
         'paged' => $paged,
-        'cache_tags' => $view->getExecutable()->getCacheTags(),
+        'cache_tags' => $view->getCacheTags(),
         'cache_contexts' => $view->getCacheContexts(),
         'cache_max_age' => $view->getCacheMaxAge(),
       ] + $basePluginDefinition;

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -70,7 +70,7 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
           $metadata->addCacheTags($row->getCacheTags());
         }
       }
-      return [$metadata];
+      return [$metadata, $value, $args];
     }
     return parent::getCacheDependencies($result, $value, $args);
   }

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -2,11 +2,14 @@
 
 namespace Drupal\graphql_views\Plugin\GraphQL\Fields;
 
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Drupal\views\ViewExecutable;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Youshido\GraphQL\Execution\ResolveInfo;
 
@@ -54,6 +57,22 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       $pluginDefinition,
       $container->get('entity_type.manager')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheDependencies($result, $value, array $args) {
+    if (isset($result)) {
+      $metadata = new CacheableMetadata();
+      foreach ($result as $row) {
+        if ($row instanceof CacheableDependencyInterface || $row instanceof ViewExecutable) {
+          $metadata->addCacheTags($row->getCacheTags());
+        }
+      }
+      return [$metadata];
+    }
+    return parent::getCacheDependencies($result, $value, $args);
   }
 
   /**

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\graphql_views\Plugin\GraphQL\Fields;
 
-use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\EntityInterface;
@@ -64,13 +63,18 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
    */
   public function getCacheDependencies($result, $value, array $args) {
     if (isset($result)) {
-      $metadata = new CacheableMetadata();
+      $dependencies = [
+        'metadata' => new CacheableMetadata(),
+      ];
       foreach ($result as $row) {
-        if ($row instanceof CacheableDependencyInterface || $row instanceof ViewExecutable) {
-          $metadata->addCacheTags($row->getCacheTags());
+        if ($row instanceof ViewExecutable) {
+          $dependencies['metadata']->addCacheTags($row->getCacheTags());
+        }
+        else {
+          $dependencies[] = $row;
         }
       }
-      return [$metadata, $value, $args];
+      return $dependencies;
     }
     return parent::getCacheDependencies($result, $value, $args);
   }

--- a/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
+++ b/modules/graphql_views/src/Plugin/GraphQL/Fields/View.php
@@ -61,7 +61,7 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function getCacheDependencies($result, $value, array $args) {
+  public function getCacheDependencies($result, $parent, array $args) {
     if (isset($result)) {
       $dependencies = [
         'metadata' => new CacheableMetadata(),
@@ -76,7 +76,7 @@ class View extends FieldPluginBase implements ContainerFactoryPluginInterface {
       }
       return $dependencies;
     }
-    return parent::getCacheDependencies($result, $value, $args);
+    return parent::getCacheDependencies($result, $parent, $args);
   }
 
   /**


### PR DESCRIPTION
For example, the 'node_list' tag is returned only by the cache plugin of the executable view.