### PR TITLE
RenderedField: Fix empty result for fields being rendered multiple times

### DIFF
--- a/modules/graphql_content/src/Plugin/GraphQL/Fields/RenderedField.php
+++ b/modules/graphql_content/src/Plugin/GraphQL/Fields/RenderedField.php
@@ -81,7 +81,10 @@ class RenderedField extends FieldPluginBase implements ContainerFactoryPluginInt
       }
       else {
         foreach (Element::children($value->_graphql_build[$value->id()][$field]) as $index) {
-          yield trim($this->renderer->renderRoot($value->_graphql_build[$value->id()][$field][$index]));
+          // Copy the field elements to $elements to avoid changes to the
+          // original element array.
+          $elements = $value->_graphql_build[$value->id()][$field][$index];
+          yield trim($this->renderer->renderRoot($elements));
         }
       }
     }

--- a/modules/graphql_content/tests/queries/rendered_fields.gql
+++ b/modules/graphql_content/tests/queries/rendered_fields.gql
@@ -3,6 +3,7 @@ query ($path: String!) {
     entity {
       ... on NodeTest {
         body
+        content:body
         fieldKeywords
         test
       }

--- a/modules/graphql_content/tests/src/Kernel/EntityRenderedFieldsTest.php
+++ b/modules/graphql_content/tests/src/Kernel/EntityRenderedFieldsTest.php
@@ -108,6 +108,7 @@ class EntityRenderedFieldsTest extends GraphQLFileTestBase {
     $this->assertNotNull($node, 'A node has been retrieved.');
 
     $this->assertEquals('<p>test</p>', $node['body'], 'Body field retrieved properly.');
+    $this->assertEquals('<p>test</p>', $node['content'], 'Body alias field retrieved properly.');
     $this->assertEquals([
       '<p>a</p>',
       '<p>b</p>',


### PR DESCRIPTION
For example, `tests/queries/rendered_fields.gql`:

After the first time rendering of the body field its element array will be populated with:

```php
[#children] => stdClass Object
  (
    [__CLASS__] => Drupal\Core\Render\Markup
    [string:protected] => '<p>test</p>'
  )

[#printed] => 1
```
It's **printed**, hence the following renderings for the body fields end up an empty result.
