### PR TITLE
Remove condition which is always true

### DIFF
--- a/modules/graphql_content/src/ContentEntitySchemaConfig.php
+++ b/modules/graphql_content/src/ContentEntitySchemaConfig.php
@@ -82,7 +82,7 @@ class ContentEntitySchemaConfig {
 
     list($type, $mode) = explode('.', $viewMode);
 
-    return $viewMode !== '__none__' ? $mode : FALSE;
+    return $mode;
 
   }
 


### PR DESCRIPTION
6 lines above (line 79) there is a `$viewMode == '__none__'` check .
So the `$viewMode !== '__none__'` condition is always true here.