### PR TITLE
Integrated deferred resolving.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
   # installing Drupal 8.2.
   - composer self-update
   # Bring in the module dependencies without requiring a merge plugin
-  - composer require youshido/graphql
+  - composer require youshido/graphql:dev-master
   # The require already triggered the install.
 
   # Start a web server on port 8888, run in the background.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
   # installing Drupal 8.2.
   - composer self-update
   # Bring in the module dependencies without requiring a merge plugin
-  - composer require youshido/graphql:dev-master
+  - composer require youshido/graphql:~1.5
   # The require already triggered the install.
 
   # Start a web server on port 8888, run in the background.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://drupal.org/project/graphql",
   "license": "GPL-2.0+",
   "require": {
-    "youshido/graphql": "~1.4"
+    "youshido/graphql": "dev-master"
   },
   "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://drupal.org/project/graphql",
   "license": "GPL-2.0+",
   "require": {
-    "youshido/graphql": "dev-master"
+    "youshido/graphql": "~1.5"
   },
   "minimum-stability": "dev"
 }

--- a/modules/graphql_core/graphql_core.services.yml
+++ b/modules/graphql_core/graphql_core.services.yml
@@ -106,6 +106,8 @@ services:
     class: Drupal\graphql_core\GraphQLContextRepository
     tags:
       - { name: service_collector, tag: context_provider, call: addContextProvider }
+  graphql_core.batched_resolver:
+    class: Drupal\graphql_core\BatchedFieldResolver
   graphql_core.schema_provider:
     class: Drupal\graphql_core\PluggableSchemaProvider
     arguments:

--- a/modules/graphql_core/src/BatchedFieldResolver.php
+++ b/modules/graphql_core/src/BatchedFieldResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\graphql_core;
+
+use Drupal\graphql_core\GraphQL\BatchedFieldInterface;
+
+/**
+ * Queueing service for deferred field resolution.
+ */
+class BatchedFieldResolver {
+  protected $queue;
+
+  /**
+   * Add a new field evaluation to the queue.
+   *
+   * @param \Drupal\graphql_core\GraphQL\BatchedFieldInterface $batchedField
+   *   The field instance.
+   * @param mixed $value
+   *   The parent value.
+   * @param array $args
+   *   The arguments it has been invoked with.
+   *
+   * @return array
+   *   A ticket that has to be used to retrieve the evaluation result.
+   */
+  public function enqueue(BatchedFieldInterface $batchedField, $value, array $args) {
+    $id = $batchedField->getBatchId($value, $args);
+    $this->queue[$id][] = [
+      'parent' => $value,
+      'arguments' => $args,
+      'field' => $batchedField,
+    ];
+    return [$id, max(array_keys($this->queue[$id]))];
+  }
+
+  /**
+   * Retrieve a result for a specific ticket.
+   *
+   * @param array $key
+   *   The deferred evaluation ticket.
+   *
+   * @return mixed
+   *   The evaluation result.
+   *
+   * @throws \Exception
+   *   In case the ticket is not valid any more.
+   */
+  public function resolve(array $key) {
+    list($id, $item) = $key;
+    if (!array_key_exists($id, $this->queue) || !array_key_exists($item, $this->queue[$id])) {
+      throw new \Exception("Requesting unregistered batched result: " . serialize($key));
+    }
+    if (!array_key_exists('result', $this->queue[$id][$item])) {
+      foreach ($this->queue[$id][$item]['field']->prepareBatch($this->queue[$id]) as $index => $result) {
+        $this->queue[$id][$index]['result'] = $result;
+      }
+    }
+    $result = $this->queue[$id][$item]['result'];
+    unset($this->queue[$id][$item]);
+    return $result;
+  }
+
+}

--- a/modules/graphql_core/src/BatchedFieldResolver.php
+++ b/modules/graphql_core/src/BatchedFieldResolver.php
@@ -3,6 +3,7 @@
 namespace Drupal\graphql_core;
 
 use Drupal\graphql_core\GraphQL\BatchedFieldInterface;
+use Youshido\GraphQL\Execution\ResolveInfo;
 
 /**
  * Queueing service for deferred field resolution.
@@ -25,15 +26,18 @@ class BatchedFieldResolver {
    *   The parent value.
    * @param array $args
    *   The arguments it has been invoked with.
+   * @param ResolveInfo $info
+   *   The graphql resolve info object.
    *
    * @return \Drupal\graphql_core\BatchedFieldResult
    *   A lazily evaluated batched field result.
    */
-  public function add(BatchedFieldInterface $batchedField, $value, array $args) {
-    $buffer = $batchedField->getBatchId($value, $args);
+  public function add(BatchedFieldInterface $batchedField, $value, array $args, ResolveInfo $info) {
+    $buffer = $batchedField->getBatchId($value, $args, $info);
     $this->buffers[$buffer][] = [
       'parent' => $value,
       'arguments' => $args,
+      'info' => $info,
       'field' => $batchedField,
     ];
     return new BatchedFieldResult($this, $buffer, max(array_keys($this->buffers[$buffer])));

--- a/modules/graphql_core/src/BatchedFieldResult.php
+++ b/modules/graphql_core/src/BatchedFieldResult.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\graphql_core;
+
+/**
+ * A callable lazy result token.
+ */
+class BatchedFieldResult {
+
+  /**
+   * The batched field resolver to get the result from.
+   *
+   * @var \Drupal\graphql_core\BatchedFieldResolver
+   */
+  protected $batchedFieldResolver;
+
+  /**
+   * The buffer id.
+   *
+   * @var string
+   */
+  protected $buffer;
+
+  /**
+   * The item id.
+   *
+   * @var string
+   */
+  protected $item;
+
+  /**
+   * BatchedFieldResult constructor.
+   *
+   * @param \Drupal\graphql_core\BatchedFieldResolver $batchedFieldResolver
+   *   The batched field resolver.
+   * @param string $buffer
+   *   The buffer id.
+   * @param string $item
+   *   The buffer item id.
+   */
+  public function __construct(BatchedFieldResolver $batchedFieldResolver, $buffer, $item) {
+    $this->batchedFieldResolver = $batchedFieldResolver;
+    $this->buffer = $buffer;
+    $this->item = $item;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __invoke() {
+    return $this->batchedFieldResolver->resolve($this->buffer, $this->item);
+  }
+
+}

--- a/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
+++ b/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
@@ -31,7 +31,7 @@ interface BatchedFieldInterface {
   public function getBatchId($parent, array $arguments);
 
   /**
-   * Prepare multiple field values at once.
+   * Resolve multiple field values at once.
    *
    * The `$batch` input argument is a list of associative arrays with "value"
    * and "arguments", reflecting the parent value and argument parameters
@@ -43,6 +43,6 @@ interface BatchedFieldInterface {
    * @return array
    *   The prepared values for each batch item.
    */
-  public function prepareBatch(array $batch);
+  public function resolveBatch(array $batch);
 
 }

--- a/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
+++ b/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\graphql_core\GraphQL;
 
+use Youshido\GraphQL\Execution\ResolveInfo;
+
 /**
  * Interface for fields that can be evaluated in optimized batches.
  */
@@ -24,18 +26,20 @@ interface BatchedFieldInterface {
    *   The parent value in the result tree.
    * @param array $arguments
    *   The list of arguments.
+   * @param ResolveInfo $info
+   *   The graphql resolve info object.
    *
    * @return string
    *   The batch key.
    */
-  public function getBatchId($parent, array $arguments);
+  public function getBatchId($parent, array $arguments, ResolveInfo $info);
 
   /**
    * Resolve multiple field values at once.
    *
-   * The `$batch` input argument is a list of associative arrays with "value"
-   * and "arguments", reflecting the parent value and argument parameters
-   * of the distinct field invocations.
+   * The `$batch` input argument is a list of associative arrays with "value",
+   * "arguments" and "info", reflecting the parent value, argument parameters
+   * and resolve info of the distinct field invocations.
    *
    * @param array $batch
    *   The list of items in the batch.

--- a/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
+++ b/modules/graphql_core/src/GraphQL/BatchedFieldInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\graphql_core\GraphQL;
+
+/**
+ * Interface for fields that can be evaluated in optimized batches.
+ */
+interface BatchedFieldInterface {
+
+  /**
+   * Retrieve the instance of a batched field resolver.
+   *
+   * @return \Drupal\graphql_core\BatchedFieldResolver
+   *   The field resolver instance.
+   */
+  public function getBatchedFieldResolver();
+
+  /**
+   * Returns string identifying the batch.
+   *
+   * Only fields with the same batch key will be grouped for evaluation.
+   *
+   * @param mixed $parent
+   *   The parent value in the result tree.
+   * @param array $arguments
+   *   The list of arguments.
+   *
+   * @return string
+   *   The batch key.
+   */
+  public function getBatchId($parent, array $arguments);
+
+  /**
+   * Prepare multiple field values at once.
+   *
+   * The `$batch` input argument is a list of associative arrays with "value"
+   * and "arguments", reflecting the parent value and argument parameters
+   * of the distinct field invocations.
+   *
+   * @param array $batch
+   *   The list of items in the batch.
+   *
+   * @return array
+   *   The prepared values for each batch item.
+   */
+  public function prepareBatch(array $batch);
+
+}

--- a/modules/graphql_core/src/GraphQL/FieldPluginBase.php
+++ b/modules/graphql_core/src/GraphQL/FieldPluginBase.php
@@ -29,10 +29,9 @@ abstract class FieldPluginBase extends AbstractField implements GraphQLPluginInt
    */
   public function resolve($value, array $args, ResolveInfo $info) {
     if ($this instanceof BatchedFieldInterface) {
-      $promise = $this->getBatchedFieldResolver()->enqueue($this, $value, $args);
-      return new DeferredResolver(function () use ($promise, $args, $info) {
-        $value = $this->getBatchedFieldResolver()->resolve($promise);
-        $result = iterator_to_array($this->resolveValues($value, $args, $info));
+      $result = $this->getBatchedFieldResolver()->add($this, $value, $args);
+      return new DeferredResolver(function () use ($result, $args, $info, $value) {
+        $result = iterator_to_array($this->resolveValues($result(), $args, $info));
         return $this->cacheable($result, $value, $args);
       });
     }

--- a/modules/graphql_core/src/GraphQL/FieldPluginBase.php
+++ b/modules/graphql_core/src/GraphQL/FieldPluginBase.php
@@ -25,6 +25,29 @@ abstract class FieldPluginBase extends AbstractField implements GraphQLPluginInt
   use ArgumentAwarePluginTrait;
 
   /**
+   * Dummy implementation for `getBatchId` in `BatchedFieldInterface`.
+   *
+   * This provides an empty implementation of `getBatchId` in case the subclass
+   * implements `BatchedFieldInterface`. In may cases this will suffice since
+   * the batches are already grouped by the class implementing `resolveBatch`.
+   * `getBatchId` is only necessary for cases where batch grouping depends on
+   * runtime arguments.
+   *
+   * @param mixed $parent
+   *   The parent value in the result tree.
+   * @param array $arguments
+   *   The list of arguments.
+   * @param ResolveInfo $info
+   *   The graphql resolve info object.
+   *
+   * @return string
+   *   The batch key.
+   */
+  public function getBatchId($parent, array $arguments, ResolveInfo $info) {
+    return '';
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function resolve($value, array $args, ResolveInfo $info) {

--- a/modules/graphql_core/src/GraphQL/FieldPluginBase.php
+++ b/modules/graphql_core/src/GraphQL/FieldPluginBase.php
@@ -29,7 +29,7 @@ abstract class FieldPluginBase extends AbstractField implements GraphQLPluginInt
    */
   public function resolve($value, array $args, ResolveInfo $info) {
     if ($this instanceof BatchedFieldInterface) {
-      $result = $this->getBatchedFieldResolver()->add($this, $value, $args);
+      $result = $this->getBatchedFieldResolver()->add($this, $value, $args, $info);
       return new DeferredResolver(function () use ($result, $args, $info, $value) {
         $result = iterator_to_array($this->resolveValues($result(), $args, $info));
         return $this->cacheable($result, $value, $args);

--- a/modules/graphql_core/tests/modules/graphql_batched_test/graphql_batched_test.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/graphql_batched_test.info.yml
@@ -1,0 +1,8 @@
+type: module
+name: GraphQL Batched Test
+description: Test scenario for batched field resolving.
+package: Testing
+core: 8.x
+hidden: TRUE
+dependencies:
+- graphql_core

--- a/modules/graphql_core/tests/modules/graphql_batched_test/graphql_batched_test.services.yml
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/graphql_batched_test.services.yml
@@ -1,0 +1,3 @@
+services:
+  graphql_batched_test.user_database:
+    class: '\Drupal\graphql_batched_test\UserDatabase'

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Foe.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Foe.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\graphql_batched_test\Plugin\GraphQL\Fields;
+
+/**
+ * The users foe.
+ *
+ * @GraphQLField(
+ *   id = "foe",
+ *   name = "foe",
+ *   types = {"User"},
+ *   type = "User",
+ * )
+ */
+class Foe extends Users {
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Friends.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Friends.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\graphql_batched_test\Plugin\GraphQL\Fields;
+
+/**
+ * A list of friends.
+ *
+ * @GraphQLField(
+ *   id = "friends",
+ *   name = "friends",
+ *   types = {"User"},
+ *   type = "User",
+ *   multi = true
+ * )
+ */
+class Friends extends Users {
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Name.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Name.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\graphql_batched_test\Plugin\GraphQL\Fields;
+
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+/**
+ * The users name.
+ *
+ * @GraphQLField(
+ *   id = "name",
+ *   name = "name",
+ *   types = {"User"},
+ *   type = "String"
+ * )
+ */
+class Name extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveInfo $info) {
+    yield $value['name'];
+  }
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
@@ -46,7 +46,7 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
    * {@inheritdoc}
    */
   public function getBatchId($parent, array $arguments) {
-    return "users";
+    return 'users';
   }
 
   /**
@@ -59,7 +59,7 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
   /**
    * {@inheritdoc}
    */
-  public function prepareBatch(array $batch) {
+  public function resolveBatch(array $batch) {
     // Turn the list of method arguments into a list of user requirements.
     $resultMap = array_map(function ($item) {
       return $this->getRequirementsFromArgs($item['parent'], $item['arguments']);
@@ -80,7 +80,6 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
         return $users[$uid];
       }, $item);
     }, $resultMap);
-
   }
 
   /**
@@ -101,9 +100,7 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
         isset($parent['foe']) ? [$parent['foe']] : []
       );
     }
-    else {
-      return array_key_exists('uids', $arguments) ? $arguments['uids'] : [];
-    }
+    return array_key_exists('uids', $arguments) ? $arguments['uids'] : [];
   }
 
   /**

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\graphql_batched_test\Plugin\GraphQL\Fields;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql_batched_test\UserDataBaseInterface;
+use Drupal\graphql_core\BatchedFieldResolver;
+use Drupal\graphql_core\GraphQL\BatchedFieldInterface;
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+/**
+ * A basic user field.
+ *
+ * @GraphQLField(
+ *   id = "users",
+ *   name = "users",
+ *   type = "User",
+ *   multi = true,
+ *   arguments = {
+ *     "uids" = {
+ *       "type" = "String",
+ *       "multi" = true
+ *     }
+ *   }
+ * )
+ */
+class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, BatchedFieldInterface {
+
+  /**
+   * The user database.
+   *
+   * @var \Drupal\graphql_batched_test\UserDataBaseInterface
+   */
+  protected $userDatabase;
+
+  /**
+   * The batched field resolver.
+   *
+   * @var \Drupal\graphql_core\BatchedFieldResolver
+   */
+  protected $batchedFieldResolver;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBatchId($parent, array $arguments) {
+    return "users";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBatchedFieldResolver() {
+    return $this->batchedFieldResolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareBatch(array $batch) {
+    // Turn the list of method arguments into a list of user requirements.
+    $resultMap = array_map(function ($item) {
+      return $this->getRequirementsFromArgs($item['parent'], $item['arguments']);
+    }, $batch);
+
+    // Reduce this list into one list of users to fetch.
+    $uids = array_unique(array_reduce($resultMap, 'array_merge', []));
+
+    // Sort them so we can predict the input argument.
+    sort($uids);
+
+    // Actually fetch the users.
+    $users = $this->userDatabase->fetchUsers($uids);
+
+    // Map the fetched users back into the result map.
+    return array_map(function ($item) use ($users) {
+      return array_map(function ($uid) use ($users) {
+        return $users[$uid];
+      }, $item);
+    }, $resultMap);
+
+  }
+
+  /**
+   * Extract the list of required user ids from field arguments.
+   *
+   * @param mixed $parent
+   *   The parent value.
+   * @param array $arguments
+   *   The field arguments.
+   *
+   * @return string[]
+   *   The required user ids.
+   */
+  protected function getRequirementsFromArgs($parent, array $arguments) {
+    if ($parent) {
+      return array_merge(
+        isset($parent['friends']) ? $parent['friends'] : [],
+        isset($parent['foe']) ? [$parent['foe']] : []
+      );
+    }
+    else {
+      return array_key_exists('uids', $arguments) ? $arguments['uids'] : [];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('graphql_batched_test.user_database'),
+      $container->get('graphql_core.batched_resolver')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $pluginId,
+    $pluginDefinition,
+    UserDataBaseInterface $userDataBase,
+    BatchedFieldResolver $batchedFieldResolver
+  ) {
+    $this->batchedFieldResolver = $batchedFieldResolver;
+    $this->userDatabase = $userDataBase;
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveInfo $info) {
+    foreach ($value as $user) {
+      yield $user;
+    }
+  }
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
@@ -45,7 +45,7 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
   /**
    * {@inheritdoc}
    */
-  public function getBatchId($parent, array $arguments) {
+  public function getBatchId($parent, array $arguments, ResolveInfo $info) {
     return 'users';
   }
 

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Fields/Users.php
@@ -45,13 +45,6 @@ class Users extends FieldPluginBase implements ContainerFactoryPluginInterface, 
   /**
    * {@inheritdoc}
    */
-  public function getBatchId($parent, array $arguments, ResolveInfo $info) {
-    return 'users';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getBatchedFieldResolver() {
     return $this->batchedFieldResolver;
   }

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Types/User.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/Plugin/GraphQL/Types/User.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\graphql_batched_test\Plugin\GraphQL\Types;
+
+use Drupal\graphql_core\GraphQL\TypePluginBase;
+
+/**
+ * A user type for testing.
+ *
+ * @GraphQLType(
+ *   id = "user",
+ *   name = "User"
+ * )
+ */
+class User extends TypePluginBase {
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/UserDataBaseInterface.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/UserDataBaseInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\graphql_batched_test;
+
+/**
+ * Dummy user database service interface.
+ */
+interface UserDataBaseInterface {
+
+  /**
+   * Retrieve user objects by their id's.
+   *
+   * @param string[] $ids
+   *   The list of ids.
+   *
+   * @return array
+   *   The list of user objects.
+   */
+  public function fetchUsers(array $ids);
+
+}

--- a/modules/graphql_core/tests/modules/graphql_batched_test/src/UserDatabase.php
+++ b/modules/graphql_core/tests/modules/graphql_batched_test/src/UserDatabase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\graphql_batched_test;
+
+/**
+ * Empty UserDatabaseInterface implementation.
+ *
+ * Replaced by a prophecy in tests.
+ */
+class UserDatabase implements UserDataBaseInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetchUsers(array $ids) {}
+
+}

--- a/modules/graphql_core/tests/queries/batched.gql
+++ b/modules/graphql_core/tests/queries/batched.gql
@@ -1,0 +1,15 @@
+query {
+  a:users(uids: ["a"]) {
+    name
+    friends {
+      name
+    }
+  }
+
+  b:users(uids: ["b"]) {
+    name
+    foe {
+      name
+    }
+  }
+}

--- a/modules/graphql_core/tests/src/Kernel/BatchedTest.php
+++ b/modules/graphql_core/tests/src/Kernel/BatchedTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\Tests\graphql_core\Kernel;
+
+use Drupal\graphql_batched_test\UserDataBaseInterface;
+use Drupal\simpletest\ContentTypeCreationTrait;
+use Drupal\simpletest\NodeCreationTrait;
+
+/**
+ * Test batched field resolving.
+ *
+ * @group graphql_core
+ */
+class BatchedTest extends GraphQLFileTestBase {
+  use ContentTypeCreationTrait;
+  use NodeCreationTrait;
+
+  public static $modules = [
+    'graphql_batched_test',
+  ];
+
+  /**
+   * Test if the schema is created properly.
+   */
+  public function testBatchedFields() {
+    $database = $this->prophesize(UserDataBaseInterface::class);
+
+    $database->fetchUsers(['a', 'b'])->willReturn([
+      'a' => [
+        'name' => 'A',
+        'friends' => ['c', 'd'],
+      ],
+      'b' => [
+        'name' => 'B',
+        'foe' => 'e',
+      ],
+    ])->shouldBeCalledTimes(1);
+
+    $database->fetchUsers(['c', 'd', 'e'])->willReturn([
+      'c' => ['name' => 'C'],
+      'd' => ['name' => 'D'],
+      'e' => ['name' => 'E'],
+    ])->shouldBeCalledTimes(1);
+
+    $this->container->set('graphql_batched_test.user_database', $database->reveal());
+
+    $result = $this->executeQueryFile('batched.gql');
+    $this->assertEquals([
+      'a' => [
+        [
+          'name' => 'A',
+          'friends' => [
+            ['name' => 'C'],
+            ['name' => 'D'],
+          ],
+        ],
+      ],
+      'b' => [
+        [
+          'name' => 'B',
+          'foe' => ['name' => 'E'],
+        ],
+      ],
+    ], $result['data']);
+  }
+
+}

--- a/src/GraphQL/Execution/DeferredResult.php
+++ b/src/GraphQL/Execution/DeferredResult.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Execution;
+
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\graphql\GraphQL\CacheableValue;
+use Youshido\GraphQL\Execution\DeferredResolverInterface;
+use Youshido\GraphQL\Execution\DeferredResult as OriginalDeferredResult;
+
+/**
+ * Extension of deferred result with cache handling.
+ */
+class DeferredResult extends OriginalDeferredResult {
+
+  /**
+   * The metadata bag.
+   *
+   * @var \Drupal\Core\Cache\CacheableMetadata
+   */
+  protected $metadata;
+
+  /**
+   * The original callback.
+   *
+   * @var callable
+   */
+  protected $originalCallback;
+
+  /**
+   * DeferredResult constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheableMetadata $metadata
+   *   The metadata bag.
+   * @param \Youshido\GraphQL\Execution\DeferredResolverInterface $resolver
+   *   The deferred resolver.
+   * @param callable $callback
+   *   The callback to be applied after resolving.
+   */
+  public function __construct(CacheableMetadata $metadata, DeferredResolverInterface $resolver, callable $callback) {
+    $this->metadata = $metadata;
+    $this->originalCallback = $callback;
+    parent::__construct($resolver, function ($result) {
+      if ($result instanceof CacheableDependencyInterface) {
+        $this->metadata->addCacheableDependency($this);
+      }
+
+      if ($result instanceof CacheableValue) {
+        $result = $result->getValue();
+      }
+
+      return call_user_func($this->originalCallback, $result);
+    });
+  }
+
+}


### PR DESCRIPTION
This pull requests prepares the processor for deferred resolving, adds tests and introduces a new `BatchedFieldInterface` that can be implemented by fields that should be evaluated in batches (multiple at once).

The last addition is purely optional. It's still possible to simply return a deferred resolver, but with this interface, the module will take the heavy lifting of queuing and grouping deferred resolve operations.