### PR TITLE
Add dependant module graphql_content_test

### DIFF
--- a/modules/graphql_views/tests/modules/graphql_views_test/graphql_views_test.info.yml
+++ b/modules/graphql_views/tests/modules/graphql_views_test/graphql_views_test.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 dependencies:
   - graphql_views
+  - graphql_content_test
   - node
   - taxonomy
   - user


### PR DESCRIPTION
This module's View has a config dependency on the 'test' content type provided by graphql_content_test module