### PR TITLE
Attached `blocksByRegion` and context fields to root level.

### DIFF
--- a/modules/graphql_block/src/Plugin/GraphQL/Fields/BlocksByRegion.php
+++ b/modules/graphql_block/src/Plugin/GraphQL/Fields/BlocksByRegion.php
@@ -22,7 +22,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *   id = "blocks_by_region",
  *   name = "blocksByRegion",
  *   type = "Entity",
- *   types = {"Url"},
+ *   types = {"Url", "Root"},
  *   multi = true,
  *   arguments = {
  *     "region" = "String"

--- a/modules/graphql_block/tests/queries/blocks.gql
+++ b/modules/graphql_block/tests/queries/blocks.gql
@@ -1,4 +1,7 @@
 query {
+  content:blocksByRegion(region: "content") {
+    __typename
+  }
   route:route(path: "/user/login") {
     content:blocksByRegion(region: "content") {
       __typename

--- a/modules/graphql_block/tests/src/Kernel/BlockTest.php
+++ b/modules/graphql_block/tests/src/Kernel/BlockTest.php
@@ -78,6 +78,7 @@ class BlockTest extends GraphQLFileTestBase {
    */
   public function testStaticBlocks() {
     $result = $this->executeQueryFile('blocks.gql');
+    $this->assertEquals(1, count($result['data']['content']), 'Blocks can be retrieved on root level.');
     $this->assertEquals(1, count($result['data']['route']['content']), 'Block listing respects visibility settings.');
   }
 

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Context.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Context.php
@@ -17,7 +17,7 @@ use Youshido\GraphQL\Execution\ResolveInfo;
  *
  * @GraphQLField(
  *   id = "context",
- *   types = {"Url"},
+ *   types = {"Url", "Root"},
  *   nullable = true,
  *   deriver = "\Drupal\graphql_core\Plugin\Deriver\ContextDeriver"
  * )

--- a/modules/graphql_core/tests/queries/context.gql
+++ b/modules/graphql_core/tests/queries/context.gql
@@ -1,4 +1,5 @@
 query {
+  name:routeNameContext
   a:route(path: "/graphql/test/a") {
     name:routeNameContext
   }

--- a/modules/graphql_core/tests/src/Kernel/ContextTest.php
+++ b/modules/graphql_core/tests/src/Kernel/ContextTest.php
@@ -24,6 +24,8 @@ class ContextTest extends GraphQLFileTestBase {
   public function testSimpleContext() {
     $values = $this->executeQueryFile('context.gql');
     $this->assertEquals([
+      // There is no root level route executed in Kernel tests.
+      'name' => '<none>',
       'a' => ['name' => 'graphql_context_test.a'],
       'b' => ['name' => 'graphql_context_test.b'],
     ], $values['data']);


### PR DESCRIPTION
All context and block fields can be invoked on root level without a sub request. Obviously this doesn't make sense for route-sensitive contexts (e.g. `nodeContext`) but I helps for a couple of other cases and fixes #194.