### PR TITLE
Consistent Typed Data mapping

### DIFF
--- a/modules/graphql_content/src/Plugin/Deriver/EntityBundleDeriver.php
+++ b/modules/graphql_content/src/Plugin/Deriver/EntityBundleDeriver.php
@@ -84,6 +84,7 @@ class EntityBundleDeriver extends DeriverBase implements ContainerDeriverInterfa
           $this->derivatives[$typeId . '-' . $bundle] = [
             'name' => StringHelper::camelCase([$typeId, $bundle]),
             'entity_type' => $typeId,
+            'data_type' => 'entity:' . $typeId . ':' . $bundle,
             'interfaces' => [StringHelper::camelCase($typeId)],
             'bundle' => $bundle,
           ] + $basePluginDefinition;

--- a/modules/graphql_content_mutation/src/Plugin/Deriver/EntityInputDeriver.php
+++ b/modules/graphql_content_mutation/src/Plugin/Deriver/EntityInputDeriver.php
@@ -123,6 +123,7 @@ class EntityInputDeriver extends DeriverBase implements ContainerDeriverInterfac
             'fields' => $createFields,
             'entity_type' => $entityTypeId,
             'entity_bundle' => $bundleName,
+            'data_type' => implode(':', ['entity', $entityTypeId, $bundleName]),
           ] + $basePluginDefinition;
         }
 
@@ -132,6 +133,7 @@ class EntityInputDeriver extends DeriverBase implements ContainerDeriverInterfac
             'fields' => $updateFields,
             'entity_type' => $entityTypeId,
             'entity_bundle' => $bundleName,
+            'data_type' => implode(':', ['entity', $entityTypeId, $bundleName]),
           ] + $basePluginDefinition;
         }
       }

--- a/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/ArgumentAwarePluginTrait.php
@@ -66,14 +66,10 @@ trait ArgumentAwarePluginTrait {
    */
   protected function buildArgumentType(GraphQLSchemaManagerInterface $schemaManager, $argument) {
     if (is_array($argument) && array_key_exists('data_type', $argument) && $argument['data_type']) {
-      $types = $schemaManager->find(function($definition) use ($argument) {
-        return array_key_exists('data_type', $definition) && $definition['data_type'] === $argument['data_type'];
-      }, [
+      $type = $schemaManager->findByDataType($argument['data_type'], [
         GRAPHQL_CORE_INPUT_TYPE_PLUGIN,
         GRAPHQL_CORE_SCALAR_PLUGIN,
-      ]);
-
-      $type = array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
+      ]) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
     }
     else {
       $typeInfo = is_array($argument) ? $argument['type'] : $argument;

--- a/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
+++ b/modules/graphql_core/src/GraphQL/Traits/TypedPluginTrait.php
@@ -79,15 +79,7 @@ trait TypedPluginTrait {
       $definition = $this->getPluginDefinition();
 
       if (array_key_exists('data_type', $definition) && $definition['data_type']) {
-        $types = $schemaManager->find(function($def) use ($definition) {
-          return array_key_exists('data_type', $def) && $def['data_type'] === $definition['data_type'];
-        }, [
-          GRAPHQL_CORE_TYPE_PLUGIN,
-          GRAPHQL_CORE_INTERFACE_PLUGIN,
-          GRAPHQL_CORE_SCALAR_PLUGIN,
-        ]);
-
-        $type = array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
+        $type = $schemaManager->findByDataType($definition['data_type']);
       }
       else if (array_key_exists('type', $definition) && $definition['type']) {
         $type = is_array($definition['type']) ? $this->buildEnumConfig($definition['type'], $definition['enum_type_name']) : $schemaManager->findByName($definition['type'], [

--- a/modules/graphql_core/src/GraphQLSchemaManager.php
+++ b/modules/graphql_core/src/GraphQLSchemaManager.php
@@ -85,6 +85,34 @@ class GraphQLSchemaManager implements GraphQLSchemaManagerInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function findByDataType($dataType, array $types = [
+    GRAPHQL_CORE_TYPE_PLUGIN,
+    GRAPHQL_CORE_INTERFACE_PLUGIN,
+    GRAPHQL_CORE_SCALAR_PLUGIN,
+  ]) {
+    $chain = explode(':', $dataType);
+
+    while ($chain) {
+      $dataType = implode(':', $chain);
+
+      $types = $this->find(function($def) use ($dataType) {
+        return isset($def['data_type']) && $def['data_type'] == $dataType;
+      }, $types);
+
+      if ($types) {
+        return array_pop($types);
+      }
+
+      array_pop($chain);
+
+    }
+
+    return NULL;
+  }
+
+  /**
    * Add a plugin manager.
    *
    * @param PluginManagerInterface $pluginManager

--- a/modules/graphql_core/src/GraphQLSchemaManagerInterface.php
+++ b/modules/graphql_core/src/GraphQLSchemaManagerInterface.php
@@ -40,6 +40,27 @@ interface GraphQLSchemaManagerInterface {
   public function findByName($name, array $types);
 
   /**
+   * Find the matching GraphQL data type for a Drupal type data identifier.
+   *
+   * Respects type chains. `entity:node:article` should return the
+   * `NodeArticle` type if it is exposed or fall back to either `Node` or even
+   * `Entity` otherwise.
+   *
+   * @param string $dataType
+   *   The typed data identifier. E.g. `string` or `entity:node:article`.
+   * @param string[] $types
+   *   A list of type constants.
+   *
+   * @return object
+   *   The matching type with the highest weight.
+   */
+  public function findByDataType($dataType, array $types = [
+    GRAPHQL_CORE_TYPE_PLUGIN,
+    GRAPHQL_CORE_INTERFACE_PLUGIN,
+    GRAPHQL_CORE_SCALAR_PLUGIN,
+  ]);
+
+  /**
    * Retrieve all mutations.
    *
    * @return object[]

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Context.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Context.php
@@ -72,15 +72,7 @@ class Context extends SubrequestField {
     if ($this instanceof PluginInspectionInterface) {
       $definition = $this->getPluginDefinition();
       if (array_key_exists('data_type', $definition) && $definition['data_type']) {
-        $types = $schemaManager->find(function($def) use ($definition) {
-          return array_key_exists('data_type', $def) && $def['data_type'] == $definition['data_type'];
-        }, [
-          GRAPHQL_CORE_TYPE_PLUGIN,
-          GRAPHQL_CORE_INTERFACE_PLUGIN,
-          GRAPHQL_CORE_SCALAR_PLUGIN,
-        ]);
-
-        return array_pop($types) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
+        return $schemaManager->findByDataType($definition['data_type']) ?: $schemaManager->findByName('String', [GRAPHQL_CORE_SCALAR_PLUGIN]);
       }
     }
 

--- a/modules/graphql_core/src/Plugin/GraphQL/Interfaces/Entity.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Interfaces/Entity.php
@@ -9,7 +9,8 @@ use Drupal\graphql_core\GraphQL\InterfacePluginBase;
  *
  * @GraphQLInterface(
  *   id = "entity",
- *   name = "Entity"
+ *   name = "Entity",
+ *   data_type = "entity"
  * )
  */
 class Entity extends InterfacePluginBase {


### PR DESCRIPTION
Mapped all types with corresponding typed data types and introduced a fallback resolving. E.g. if `entity:node:article` is required and the `NodeArticle` type is not exposed it will fall back to `Node` or `Entity` first for context resolving and other parts where typed data is mapped to graphql types.

This should fix #291:

During implementation one question emerged: Right now `UnexposedEntity` allows access to all entity properties. I wonder if this is ok because entity access should handle the restrictive part. Is selective exposing an optimisation or a security feature?