### PR TITLE
Link attributes

### DIFF
--- a/modules/graphql_link/src/Plugin/GraphQL/Fields/LinkAttribute.php
+++ b/modules/graphql_link/src/Plugin/GraphQL/Fields/LinkAttribute.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\graphql_link\Plugin\GraphQL\Fields;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\link\LinkItemInterface;
+use Drupal\graphql_core\GraphQL\FieldPluginBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+/**
+ * Retrieve specific attributes of a menu link.
+ *
+ * @GraphQLField(
+ *   id = "link_item_attribute",
+ *   secure = true,
+ *   name = "attribute",
+ *   type = "String",
+ *   types = {"LinkItem"},
+ *   nullable = true,
+ *   arguments = {
+ *     "key" = "String"
+ *   }
+ * )
+ */
+class LinkAttribute extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveInfo $info) {
+    if ($value instanceof LinkItemInterface) {
+      $options = $value->getUrl()->getOptions();
+      yield NestedArray::getValue($options, ['attributes', $args['key']]);
+    }
+  }
+
+}


### PR DESCRIPTION
Attributes for Link fields (copy of MenuLinkAttribute)

Usable with any contrib module which creates a "Link with attribute(s)" widget.
