### PR TITLE
WIP: Submodule cleanup

### DIFF
--- a/modules/graphql_block/graphql_block.info.yml
+++ b/modules/graphql_block/graphql_block.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move module to graphql_core.
 name: GraphQL Block
 type: module
 description: 'Query Drupal blocks with GraphQL.'

--- a/modules/graphql_breadcrumbs/graphql_breadcrumbs.info.yml
+++ b/modules/graphql_breadcrumbs/graphql_breadcrumbs.info.yml
@@ -1,3 +1,5 @@
+# TODO: Move only breadcrumbs field to graphql_core.
+# Consolidate link functionality with the one from graphql_link.
 name: GraphQL Breadcrumbs
 type: module
 description: Expose a route's breadcrumbs to GraphQL

--- a/modules/graphql_content/graphql_content.info.yml
+++ b/modules/graphql_content/graphql_content.info.yml
@@ -1,3 +1,5 @@
+# TODO: Move EntityById to core and use EntityTypeDeriver.
+# Increase weights of rendered and displayed fields for BC.
 name: GraphQL Content
 type: module
 description: 'Automatically create GraphQL types and fields from Drupal content entities.'

--- a/modules/graphql_content_mutation/graphql_content_mutation.info.yml
+++ b/modules/graphql_content_mutation/graphql_content_mutation.info.yml
@@ -1,3 +1,4 @@
+#TODO: Move everything to graphql_core.
 name: GraphQL Content Mutations
 type: module
 description: 'Automatically create GraphQL mutations for Drupal content entities.'

--- a/modules/graphql_entity_reference/graphql_entity_reference.info.yml
+++ b/modules/graphql_entity_reference/graphql_entity_reference.info.yml
@@ -1,3 +1,4 @@
+# TODO: Keep for BC and deprecate.
 name: GraphQL Entity Reference
 type: module
 description: 'Traverse entity references in GraphQL queries.'

--- a/modules/graphql_file/graphql_file.info.yml
+++ b/modules/graphql_file/graphql_file.info.yml
@@ -1,3 +1,4 @@
+# TODO: Add FileUrl to raw data field type in core. Keep for BC and deprecate.
 name: GraphQL File
 type: module
 description: 'Retrieve detailed file field information with GraphQL.'

--- a/modules/graphql_graphiql/graphql_graphiql.info.yml
+++ b/modules/graphql_graphiql/graphql_graphiql.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to graphql base.
 name: GraphQL Explorer
 type: module
 description: 'Adds a page with the GraphiQL explorer (https://github.com/graphql/graphiql/).'

--- a/modules/graphql_image/graphql_image.info.yml
+++ b/modules/graphql_image/graphql_image.info.yml
@@ -1,3 +1,5 @@
+# TODO: Move image derivative functionality to core.
+# Attach it to legacy Image type by alter hook. Deprecate module.
 name: GraphQL Image
 type: module
 description: 'Request specific image styles in GraphQL queries.'

--- a/modules/graphql_link/graphql_link.info.yml
+++ b/modules/graphql_link/graphql_link.info.yml
@@ -1,3 +1,4 @@
+# TODO: Add Url field to link field raw data type. Deprecate module.
 name: GraphQL Link
 type: module
 description: 'Retrieve distinct properties from link fields.'

--- a/modules/graphql_menu/graphql_menu.info.yml
+++ b/modules/graphql_menu/graphql_menu.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to core.
 name: GraphQL Menu
 type: module
 description: 'Query Drupal menu trees with GraphQL.'

--- a/modules/graphql_mutation/graphql_mutation.info.yml
+++ b/modules/graphql_mutation/graphql_mutation.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to graphql base.
 name: GraphQL Mutations
 type: module
 description: 'Core module with common fields and types for enabling mutations.'

--- a/modules/graphql_query_map_entity/graphql_query_map_entity.info.yml
+++ b/modules/graphql_query_map_entity/graphql_query_map_entity.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to graphql base.
 name: GraphQL Query Map Entity
 type: module
 description: 'Store query maps as config entities.'

--- a/modules/graphql_query_map_json/graphql_query_map_json.info.yml
+++ b/modules/graphql_query_map_json/graphql_query_map_json.info.yml
@@ -1,3 +1,4 @@
+# TODO: move to graphql base.
 name: GraphQL Query Map JSON
 type: module
 description: 'Store query maps in JSON files on your local file system.'

--- a/modules/graphql_views/graphql_views.info.yml
+++ b/modules/graphql_views/graphql_views.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to graphql core.
 name: GraphQL Views
 type: module
 description: 'Adds support for views.'

--- a/modules/graphql_voyager/graphql_voyager.info.yml
+++ b/modules/graphql_voyager/graphql_voyager.info.yml
@@ -1,3 +1,4 @@
+# TODO: Move to graphql base.
 name: GraphQL Voyager
 type: module
 description: 'Adds a page with GraphQL Voyager (https://apis.guru/graphql-voyager/).'


### PR DESCRIPTION
Overall strategy:

1. Move all fully migrated modules along with their tests. Keep module *.info.yml's, but hide them.
    * graphql_block
    * graphql_content_mutation
    * graphql_graphiql
    * graphql_menu
    * graphql_mutation
    * graphql_query_map_entity
    * graphql_query_map_json
    * graphql_views
    * graphql_voyager

2. Migrate functionality of partially moved modules according to the TODO in the info.yml. Tests stay where they are. Deprecate (hide) these modules. Add tests for migrated functionality in target modules.
    * graphql_breadcrumbs
    * graphql_content
    * graphql_entity_reference
    * graphql_file
    * graphql_image
    * graphql_link

3. Stable release: Move deprecated modules to a "legacy" repository. Move "funky" modules to extra repositories:
    * graphql_json
    * graphql_xml
    * graphql_twig
