### PR TITLE
Prevent caching if an error occurs

### DIFF
--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -102,7 +102,7 @@ class QueryProcessor {
 
     // Prevent caching if this is a mutation query or an error occurs.
     $request = $context->getRequest();
-    if (!empty($request) && $request->hasMutations() || $context->hasErrors()) {
+    if ((!empty($request) && $request->hasMutations()) || $context->hasErrors()) {
       $metadata->setCacheMaxAge(0);
     }
 

--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -100,9 +100,9 @@ class QueryProcessor {
       $metadata->addCacheableDependency($container->get('metadata'));
     }
 
-    // Prevent caching if this is a mutation query.
+    // Prevent caching if this is a mutation query or an error occurs.
     $request = $context->getRequest();
-    if (!empty($request) && $request->hasMutations()) {
+    if (!empty($request) && $request->hasMutations() || $context->hasErrors()) {
       $metadata->setCacheMaxAge(0);
     }
 


### PR DESCRIPTION
An error might happen temporarily, for example, a HTTP timeout error when backend server requested a 3rd party service. For other cases I think it also makes sense.