### PR TITLE
Fix usages of InvalidPluginDefinitionException

### DIFF
--- a/src/Plugin/GraphQL/PluggableSchemaBuilder.php
+++ b/src/Plugin/GraphQL/PluggableSchemaBuilder.php
@@ -81,7 +81,7 @@ class PluggableSchemaBuilder implements PluggableSchemaBuilderInterface {
       foreach ($manager->getDefinitions() as $id => $definition) {
         $name = $definition['name'];
         if (empty($name)) {
-          throw new InvalidPluginDefinitionException('Invalid GraphQL plugin definition. No name defined.');
+          throw new InvalidPluginDefinitionException($id, 'Invalid GraphQL plugin definition. No name defined.');
         }
 
         if (!array_key_exists($name, $items) || $items[$name]['weight'] < $definition['weight']) {
@@ -119,7 +119,7 @@ class PluggableSchemaBuilder implements PluggableSchemaBuilderInterface {
     }, $types);
 
     if (empty($result)) {
-      throw new InvalidPluginDefinitionException(sprintf('GraphQL plugin with name %s could not be found.', $name));
+      throw new InvalidPluginDefinitionException(null, sprintf('GraphQL plugin with name %s could not be found.', $name));
     }
 
     return array_pop($result);

--- a/src/Plugin/GraphQL/SchemaPluginManager.php
+++ b/src/Plugin/GraphQL/SchemaPluginManager.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\graphql\Plugin\GraphQL;
 
-use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;


### PR DESCRIPTION
If you mess up the field types in a plugin annotation, an `InvalidPluginDefinitionException` exception is thrown. However, the first parameter to the constructor is supposed to be a `$plugin_id`, not the message, so the helpful hint is not actually printed.

Current message:
> The website encountered an unexpected error. Please try again later.
>
>Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException: in Drupal\graphql\Plugin\GraphQL\PluggableSchemaBuilder->findByName() (line 122 of modules/contrib/graphql/src/Plugin/GraphQL/PluggableSchemaBuilder.php).

Fixed message (emphasis mine):
>The website encountered an unexpected error. Please try again later.
>
>Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException: **GraphQL plugin with name string could not be found.** in Drupal\graphql\Plugin\GraphQL\PluggableSchemaBuilder->findByName() (line 122 of modules/contrib/graphql/src/Plugin/GraphQL/PluggableSchemaBuilder.php).

Example broken annotation that causes this exception:
```php
/**
 * @GraphQLInputType(
 *   id = "test_input",
 *   name = "TestInput",
 *   fields = {
 *     "title" = "string",
 *   }
 * )
 */
```

I also found an extraneous `use` statement while searching for other usages which I removed.