### PR TITLE
SubRequestResponse:result is an array.

### DIFF
--- a/src/GraphQL/Buffers/SubRequestResponse.php
+++ b/src/GraphQL/Buffers/SubRequestResponse.php
@@ -9,14 +9,14 @@ class SubRequestResponse extends Response {
   /**
    * The request result.
    *
-   * @var mixed
+   * @var array
    */
   protected $result;
 
   /**
    * SubrequestResponse constructor.
    *
-   * @param mixed $result
+   * @param array $result
    *   The request result.
    * @param int $status
    *   The response status code.
@@ -31,7 +31,7 @@ class SubRequestResponse extends Response {
   /**
    * Gets the request result.
    *
-   * @return mixed
+   * @return array
    *   The request result.
    */
   public function getResult() {


### PR DESCRIPTION
I just noticed a small flaw while looking at SubRequestResponse:result

The constructor specifies that the parameter $result is an array. So this means documenting various parts of the class as 'mixed' is not correct.

A very minor fix... I hope this is appropriate/welcome.