### PR TITLE
Graphql core test refactoring

### DIFF
--- a/modules/graphql_core/tests/modules/graphql_requests_test/src/RequestTestController.php
+++ b/modules/graphql_core/tests/modules/graphql_requests_test/src/RequestTestController.php
@@ -3,6 +3,7 @@
 namespace Drupal\graphql_requests_test;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class RequestTestController {
 
@@ -10,7 +11,7 @@ class RequestTestController {
    * A simple test controller.
    */
   public function test() {
-    return ['#markup' => '<p>Test</p>'];
+    return new Response('<p>Test</p>');
   }
 
   /**

--- a/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
@@ -4,22 +4,20 @@ namespace Drupal\Tests\graphql_core\Kernel\Blocks;
 
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Tests\block\Traits\BlockCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 
 /**
  * Test block retrieval via GraphQL.
  *
  * @group graphql_block
  */
-class BlockTest extends GraphQLTestBase {
+class BlockTest extends GraphQLCoreTestBase {
   use BlockCreationTrait;
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
-    'system',
-    'user',
     'block',
     'block_content',
     'text',
@@ -27,7 +25,6 @@ class BlockTest extends GraphQLTestBase {
     'filter',
     'editor',
     'ckeditor',
-    'graphql_core',
     'graphql_block_test',
   ];
 
@@ -42,7 +39,6 @@ class BlockTest extends GraphQLTestBase {
     $themeInstaller->install(['stark']);
 
     $this->installEntitySchema('block_content');
-    $this->installEntitySchema('user');
     $this->installConfig('block_content');
     $this->installConfig('graphql_block_test');
 

--- a/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
@@ -71,6 +71,7 @@ class BlockTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('Blocks/blocks.gql');
     $metadata = $this->defaultCacheMetaData();
 
+    // TODO: Check cache metadata.
     $metadata->addCacheTags([
       'block_content:1',
       'config:block.block.stark_powered',

--- a/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Blocks/BlockTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\graphql_core\Kernel\Blocks;
 
 use Drupal\block_content\Entity\BlockContent;
-use Drupal\Tests\block\Traits\BlockCreationTrait;
+use Drupal\simpletest\BlockCreationTrait;
 use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 
 /**

--- a/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
@@ -32,7 +32,7 @@ class BreadcrumbsTest extends GraphQLTestBase {
     $breadcrumbManager = $this->prophesize('Drupal\Core\Breadcrumb\BreadcrumbManager');
 
     $breadcrumbManager->build(Argument::any())
-      ->will(function($args) {
+      ->will(function ($args) {
         /** @var \Drupal\Core\Routing\RouteMatch $routeMatch */
         $routeMatch = $args[0];
         $breadcrumb = new Breadcrumb();

--- a/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
@@ -4,11 +4,8 @@ namespace Drupal\Tests\graphql_core\Kernel\Breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Link;
-use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use Prophecy\Argument;
 
 /**
@@ -16,9 +13,7 @@ use Prophecy\Argument;
  *
  * @group graphql_breadcrumbs
  */
-class BreadcrumbsTest extends GraphQLFileTestBase {
-  use NodeCreationTrait;
-  use ContentTypeCreationTrait;
+class BreadcrumbsTest extends GraphQLTestBase {
 
   /**
    * {@inheritdoc}
@@ -38,7 +33,7 @@ class BreadcrumbsTest extends GraphQLFileTestBase {
 
     $breadcrumbManager->build(Argument::any())
       ->will(function($args) {
-        /** @var RouteMatch $routeMatch */
+        /** @var \Drupal\Core\Routing\RouteMatch $routeMatch */
         $routeMatch = $args[0];
         $breadcrumb = new Breadcrumb();
         if ($routeMatch->getRouteName() == 'graphql_breadcrumbs_test.test') {
@@ -53,11 +48,18 @@ class BreadcrumbsTest extends GraphQLFileTestBase {
    * Test that the breadcrumb query returns breadcrumbs for given path.
    */
   public function testBreadcrumbs() {
-    $expected = [
-      ['text' => 'Test breadcrumb']
-    ];
-    $result = $this->executeQueryFile('breadcrumbs.gql', ['path' => '/breadcrumbs-test']);
-    $this->assertEquals($expected, $result['data']['route']['breadcrumb']);
+    $query = $this->getQueryFromFile('breadcrumbs.gql');
+
+    // TODO: Check cache metadata.
+    $metadata = $this->defaultCacheMetaData();
+
+    $this->assertResults($query, ['path' => '/breadcrumbs-test'], [
+      'route' => [
+        'breadcrumb' => [
+          0 => ['text' => 'Test breadcrumb'],
+        ],
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Breadcrumbs/BreadcrumbsTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\graphql_core\Kernel\Breadcrumbs;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 use Prophecy\Argument;
 
 /**
@@ -13,13 +13,12 @@ use Prophecy\Argument;
  *
  * @group graphql_breadcrumbs
  */
-class BreadcrumbsTest extends GraphQLTestBase {
+class BreadcrumbsTest extends GraphQLCoreTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
-    'graphql_core',
     'graphql_breadcrumbs_test',
   ];
 

--- a/modules/graphql_core/tests/src/Kernel/Context/ContextTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Context/ContextTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Context;
 
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 
 /**
  * Test plugin based schema generation.
  *
  * @group graphql_core
  */
-class ContextTest extends GraphQLTestBase {
+class ContextTest extends GraphQLCoreTestBase {
 
   public static $modules = [
-    'graphql_core',
     'graphql_context_test',
   ];
 
@@ -21,10 +20,14 @@ class ContextTest extends GraphQLTestBase {
    */
   public function testSimpleContext() {
     $query = $this->getQueryFromFile('context.gql');
+
+    // TODO: Check cache metadata.
+    $metadata = $this->defaultCacheMetaData();
+
     $this->assertResults($query, [], [
       'a' => ['name' => 'graphql_context_test.a'],
       'b' => ['name' => 'graphql_context_test.b'],
-    ], $this->defaultCacheMetaData());
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Context/ContextTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Context/ContextTest.php
@@ -2,18 +2,14 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Context;
 
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 
 /**
  * Test plugin based schema generation.
  *
  * @group graphql_core
  */
-class ContextTest extends GraphQLFileTestBase {
-  use ContentTypeCreationTrait;
-  use NodeCreationTrait;
+class ContextTest extends GraphQLTestBase {
 
   public static $modules = [
     'graphql_core',
@@ -24,11 +20,11 @@ class ContextTest extends GraphQLFileTestBase {
    * Test if the schema is created properly.
    */
   public function testSimpleContext() {
-    $values = $this->executeQueryFile('context.gql');
-    $this->assertEquals([
+    $query = $this->getQueryFromFile('context.gql');
+    $this->assertResults($query, [], [
       'a' => ['name' => 'graphql_context_test.a'],
       'b' => ['name' => 'graphql_context_test.b'],
-    ], $values['data']);
+    ], $this->defaultCacheMetaData());
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityBasicFieldsTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityBasicFieldsTest.php
@@ -94,16 +94,15 @@ class EntityBasicFieldsTest extends GraphQLContentTestBase {
 
 
     $query = $this->getQueryFromFile('basic_fields.gql');
-    $metadata = $this->defaultCacheMetaData();
 
     // TODO: Check cache metadata.
+    $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts([
       'languages:language_content',
       'user.node_grants:view',
     ]);
 
     $metadata->addCacheTags([
-      'config:field.storage.node.body',
       'entity_bundles',
       'entity_field_info',
       'entity_types',

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityBasicFieldsTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityBasicFieldsTest.php
@@ -2,11 +2,7 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Entity;
 
-use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\user\Traits\UserCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
-use Drupal\user\Entity\Role;
+use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
 use DateTime;
 
 /**
@@ -14,18 +10,9 @@ use DateTime;
  *
  * @group graphql_content
  */
-class EntityBasicFieldsTest extends GraphQLTestBase {
-  use ContentTypeCreationTrait;
-  use NodeCreationTrait;
-  use UserCreationTrait;
+class EntityBasicFieldsTest extends GraphQLContentTestBase {
 
   public static $modules = [
-    'graphql_core',
-    'user',
-    'node',
-    'field',
-    'filter',
-    'text',
     'language',
     'content_translation',
   ];
@@ -35,18 +22,6 @@ class EntityBasicFieldsTest extends GraphQLTestBase {
    */
   protected function setUp() {
     parent::setUp();
-
-    $this->installConfig(['user']);
-    $this->installConfig(['node']);
-    $this->installConfig(['filter']);
-    $this->installEntitySchema('node');
-    $this->installEntitySchema('user');
-    $this->installSchema('node', 'node_access');
-    $this->installSchema('system', 'sequences');
-
-    $this->createContentType([
-      'type' => 'test',
-    ]);
 
     $language = $this->container->get('entity.manager')->getStorage('configurable_language')->create([
       'id' => 'fr',
@@ -62,9 +37,7 @@ class EntityBasicFieldsTest extends GraphQLTestBase {
    */
   protected function userPermissions() {
     $perms = parent::userPermissions();
-    $perms[] = 'access content';
     $perms[] = 'edit any test content';
-    $perms[] = 'access user profiles';
     return $perms;
   }
 
@@ -127,7 +100,6 @@ class EntityBasicFieldsTest extends GraphQLTestBase {
     $metadata->addCacheContexts([
       'languages:language_content',
       'user.node_grants:view',
-      'user.permissions',
     ]);
 
     $metadata->addCacheTags([

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
@@ -70,6 +70,7 @@ class EntityByIdTest extends GraphQLContentTestBase {
       ->setTitle('English node unpublished')
       ->save();
 
+    // TODO: Check chache metadata.
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags([
       'entity_bundles',

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
@@ -2,34 +2,21 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Entity;
 
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
-use Drupal\Tests\graphql_core\Traits\RevisionsTestTrait;
-use Drupal\user\Entity\Role;
+use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
 
 /**
  * Test entity query support in GraphQL.
  *
  * @group graphql_content
  */
-class EntityByIdTest extends GraphQLFileTestBase {
-  use NodeCreationTrait;
-  use ContentTypeCreationTrait;
-  use RevisionsTestTrait;
+class EntityByIdTest extends GraphQLContentTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
-    'node',
-    'field',
-    'filter',
     'language',
     'content_translation',
-    'text',
-    'graphql_test',
-    'graphql_core',
   ];
 
   /**
@@ -51,15 +38,6 @@ class EntityByIdTest extends GraphQLFileTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->installEntitySchema('node');
-    $this->installEntitySchema('user');
-    $this->installConfig(['node', 'filter']);
-    $this->installSchema('node', 'node_access');
-    $this->createContentType(['type' => 'test']);
-
-    Role::load('anonymous')
-      ->grantPermission('access content')
-      ->save();
 
     $languageStorage = $this->container->get('entity.manager')->getStorage('configurable_language');
     $language = $languageStorage->create([
@@ -92,26 +70,44 @@ class EntityByIdTest extends GraphQLFileTestBase {
       ->setTitle('English node unpublished')
       ->save();
 
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags([
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+      'node:1',
+      'config:field.storage.node.body',
+    ]);
+
     // Check English node.
-    $result = $this->executeQueryFile('entity_by_id.gql', [
+    $this->assertResults($this->getQueryFromFile('entity_by_id.gql'), [
       'id' => $node->id(),
       'language' => 'en',
-    ]);
-    $this->assertEquals(['entityLabel' => 'English node'], $result['data']['nodeById']);
+    ], [
+      'nodeById' => [
+        'entityLabel' => 'English node',
+      ],
+    ], $metadata);
 
     // Check French translation.
-    $result = $this->executeQueryFile('entity_by_id.gql', [
+    $this->assertResults($this->getQueryFromFile('entity_by_id.gql'), [
       'id' => $node->id(),
       'language' => 'fr',
-    ]);
-    $this->assertEquals(['entityLabel' => 'French node'], $result['data']['nodeById']);
+    ], [
+      'nodeById' => [
+        'entityLabel' => 'French node',
+      ],
+    ], $metadata);
 
     // Check Chinese simplified translation.
-    $result = $this->executeQueryFile('entity_by_id.gql', [
+    $this->assertResults($this->getQueryFromFile('entity_by_id.gql'), [
       'id' => $node->id(),
       'language' => 'zh_hans',
-    ]);
-    $this->assertEquals(['entityLabel' => 'Chinese simplified node'], $result['data']['nodeById']);
+    ], [
+      'nodeById' => [
+        'entityLabel' => 'Chinese simplified node',
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
+++ b/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
@@ -2,46 +2,22 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\EntityQuery;
 
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
-use Drupal\user\Entity\Role;
+use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
 
 /**
  * Test entity query support in GraphQL.
  *
  * @group graphql_core
  */
-class EntityQueryTest extends GraphQLFileTestBase {
-  use NodeCreationTrait;
-  use ContentTypeCreationTrait;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static $modules = [
-    'graphql_core',
-    'node',
-    'field',
-    'filter',
-    'text',
-  ];
+class EntityQueryTest extends GraphQLContentTestBase {
 
   /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
-    $this->installEntitySchema('node');
-    $this->installConfig(['node', 'filter']);
-    $this->installSchema('node', 'node_access');
-
     $this->createContentType(['type' => 'a']);
     $this->createContentType(['type' => 'b']);
-
-    Role::load('anonymous')
-      ->grantPermission('access content')
-      ->save();
   }
 
   /**
@@ -73,50 +49,65 @@ class EntityQueryTest extends GraphQLFileTestBase {
     $c->save();
     $d->save();
 
-    $result = $this->executeQueryFile('entity_query.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheTags([
+      'config:field.storage.node.body',
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+      'node:' . $a->id(),
+      'node:' . $b->id(),
+      'node:' . $c->id(),
+      'node:' . $d->id(),
+      'node_list',
+    ]);
 
-    $this->assertEquals([
-      ['uuid' => $a->uuid()],
-      ['uuid' => $b->uuid()],
-      ['uuid' => $c->uuid()],
-    ], $result['data']['a']['entities'], 'Type A entities queried.');
-
-    $this->assertEquals(3, $result['data']['a']['count'], 'Correct count is returned');
-
-    $this->assertEquals([
-      ['uuid' => $d->uuid()],
-    ], $result['data']['b']['entities'], 'Type B entity queried.');
-
-    $this->assertEquals(1, $result['data']['b']['count'], 'Correct count is returned');
-
-    $this->assertEquals([
-      ['uuid' => $a->uuid()],
-      ['uuid' => $b->uuid()],
-    ], $result['data']['limit']['entities'], 'Limit works as expected.');
-
-    $this->assertEquals(3, $result['data']['limit']['count'], 'Correct count is returned');
-
-    $this->assertEquals([
-      ['uuid' => $b->uuid()],
-      ['uuid' => $c->uuid()],
-    ], $result['data']['offset']['entities'], 'Offset works as expected.');
-
-    $this->assertEquals(3, $result['data']['offset']['count'], 'Correct count is returned');
-
-    $this->assertEquals([
-      ['uuid' => $b->uuid()],
-    ], $result['data']['offset_limit']['entities'], 'Offset and limit combination works as expected.');
-
-    $this->assertEquals(3, $result['data']['offset_limit']['count'], 'Correct count is returned');
-
-    $this->assertEquals([
-      ['uuid' => $a->uuid()],
-      ['uuid' => $b->uuid()],
-      ['uuid' => $c->uuid()],
-      ['uuid' => $d->uuid()],
-    ], $result['data']['all_nodes']['entities'], 'All entities queried.');
-
-    $this->assertEquals(4, $result['data']['all_nodes']['count'], 'Correct count is returned');
+    $this->assertResults($this->getQueryFromFile('entity_query.gql'), [], [
+      'a' => [
+        'entities' => [
+          ['uuid' => $a->uuid()],
+          ['uuid' => $b->uuid()],
+          ['uuid' => $c->uuid()],
+        ],
+        'count' => 3,
+      ],
+      'b' => [
+        'entities' => [
+          ['uuid' => $d->uuid()],
+        ],
+        'count' => 1,
+      ],
+      'limit' => [
+        'entities' => [
+          ['uuid' => $a->uuid()],
+          ['uuid' => $b->uuid()],
+        ],
+        'count' => 3,
+      ],
+      'offset' => [
+        'entities' => [
+          ['uuid' => $b->uuid()],
+          ['uuid' => $c->uuid()],
+        ],
+        'count' => 3,
+      ],
+      'offset_limit' => [
+        'entities' => [
+          ['uuid' => $b->uuid()],
+        ],
+        'count' => 3,
+      ],
+      'all_nodes' => [
+        'entities' => [
+          ['uuid' => $a->uuid()],
+          ['uuid' => $b->uuid()],
+          ['uuid' => $c->uuid()],
+          ['uuid' => $d->uuid()],
+        ],
+        'count' => 4,
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
+++ b/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
@@ -49,10 +49,10 @@ class EntityQueryTest extends GraphQLContentTestBase {
     $c->save();
     $d->save();
 
+    // TODO: Check cache metadata.
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['user.node_grants:view']);
     $metadata->addCacheTags([
-      'config:field.storage.node.body',
       'entity_bundles',
       'entity_field_info',
       'entity_types',

--- a/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
+++ b/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\graphql_core\Kernel;
 
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use Drupal\Tests\graphql_core\Traits\RevisionsTestTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
@@ -13,7 +12,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 /**
  * Base class for node based tests.
  */
-class GraphQLContentTestBase extends GraphQLTestBase {
+class GraphQLContentTestBase extends GraphQLCoreTestBase {
   use ContentTypeCreationTrait;
   use UserCreationTrait;
   use NodeCreationTrait;
@@ -23,8 +22,6 @@ class GraphQLContentTestBase extends GraphQLTestBase {
    * {@inheritdoc}
    */
   public static $modules = [
-    'graphql_core',
-    'user',
     'node',
     'field',
     'filter',
@@ -51,13 +48,26 @@ class GraphQLContentTestBase extends GraphQLTestBase {
 
     $this->installConfig(['node', 'filter', 'text']);
     $this->installEntitySchema('node');
-    $this->installEntitySchema('user');
 
     $this->installSchema('node', 'node_access');
     $this->installSchema('system', 'sequences');
 
     $this->createContentType([
       'type' => 'test',
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defaultCacheTags() {
+    // graphql_core adds the node body field to the schema, which means
+    // it's always part of the result cache tags, even if it has not been
+    // queried.
+    //
+    // https://github.com/drupal-graphql/graphql/issues/500
+    return array_merge(parent::defaultCacheTags(), [
+      'config:field.storage.node.body',
     ]);
   }
 

--- a/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
+++ b/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\graphql_core\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Traits\RevisionsTestTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Base class for node based tests.
+ */
+class GraphQLContentTestBase extends GraphQLTestBase {
+  use ContentTypeCreationTrait;
+  use UserCreationTrait;
+  use NodeCreationTrait;
+  use RevisionsTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'graphql_core',
+    'user',
+    'node',
+    'field',
+    'filter',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * Add the 'access content' permission to the mocked account.
+   */
+  protected function userPermissions() {
+    $perms = parent::userPermissions();
+    $perms[] = 'access content';
+    $perms[] = 'access user profiles';
+    return $perms;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['node', 'filter', 'text']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+
+    $this->installSchema('node', 'node_access');
+    $this->installSchema('system', 'sequences');
+
+    $this->createContentType([
+      'type' => 'test',
+    ]);
+  }
+
+  /**
+   * Add a field to test content type.
+   *
+   * @param string $type
+   *   Field type.
+   * @param string $fieldName
+   *   Field machine name.
+   * @param string $label
+   *   Label for the field.
+   */
+  protected function addField($type, $fieldName, $label = 'Label', $bundle = 'test') {
+    FieldStorageConfig::create([
+      'field_name' => $fieldName,
+      'entity_type' => 'node',
+      'type' => $type,
+      'cardinality' => -1,
+    ])->save();
+
+    FieldConfig::create([
+      'entity_type' => 'node',
+      'bundle' => $bundle,
+      'field_name' => $fieldName,
+      'label' => $label,
+    ])->save();
+  }
+
+}

--- a/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
+++ b/modules/graphql_core/tests/src/Kernel/GraphQLContentTestBase.php
@@ -5,9 +5,9 @@ namespace Drupal\Tests\graphql_core\Kernel;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\graphql_core\Traits\RevisionsTestTrait;
-use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\simpletest\ContentTypeCreationTrait;
+use Drupal\simpletest\NodeCreationTrait;
+use Drupal\simpletest\UserCreationTrait;
 
 /**
  * Base class for node based tests.

--- a/modules/graphql_core/tests/src/Kernel/GraphQLCoreTestBase.php
+++ b/modules/graphql_core/tests/src/Kernel/GraphQLCoreTestBase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\graphql_core\Kernel;
+
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+
+/**
+ * Test base for drupal core graphql functionality.
+ */
+class GraphQLCoreTestBase extends GraphQLTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'graphql_core',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    // User entity schema is required for the currentUserContext field.
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defaultCacheTags() {
+    // graphql_core derives fields and types from entity information, so the
+    // cache tags are applied to the schema and end up in every result.
+    //
+    // https://github.com/drupal-graphql/graphql/issues/500
+    return array_merge(parent::defaultCacheTags(), [
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+    ]);
+  }
+
+}

--- a/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
@@ -2,35 +2,22 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Images;
 
-use Drupal\Core\Entity\Entity\EntityViewMode;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\image\Entity\ImageStyle;
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
-use Drupal\user\Entity\Role;
+use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
 
 /**
  * Test file attachments.
  *
  * @group graphql_image
  */
-class ImageFieldTest extends GraphQLFileTestBase {
-  use NodeCreationTrait;
-  use ContentTypeCreationTrait;
+class ImageFieldTest extends GraphQLContentTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
-    'node',
-    'field',
-    'text',
-    'filter',
     'file',
     'image',
-    'graphql_core',
   ];
 
   /**
@@ -38,38 +25,10 @@ class ImageFieldTest extends GraphQLFileTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->installConfig('node');
-    $this->installConfig('filter');
     $this->installConfig('image');
-    $this->installEntitySchema('node');
-    $this->installSchema('node', 'node_access');
     $this->installSchema('file', 'file_usage');
     $this->installEntitySchema('file');
-    $this->createContentType(['type' => 'test']);
-
-    Role::load('anonymous')
-      ->grantPermission('access content')
-      ->save();
-
-    EntityViewMode::create([
-      'targetEntityType' => 'node',
-      'id' => "node.graphql",
-    ])->save();
-
-
-    FieldStorageConfig::create([
-      'field_name' => 'image',
-      'type' => 'image',
-      'entity_type' => 'node',
-    ])->save();
-
-    FieldConfig::create([
-      'field_name' => 'image',
-      'entity_type' => 'node',
-      'bundle' => 'test',
-      'label' => 'Image',
-    ])->save();
-
+    $this->addField('image', 'image');
   }
 
   /**
@@ -85,15 +44,48 @@ class ImageFieldTest extends GraphQLFileTestBase {
 
     $a->save();
 
-    $result = $this->executeQueryFile('image.gql', ['path' => '/node/' . $a->id()]);
-    $image = $result['data']['route']['node']['image'];
+    $metadata = $this->defaultCacheMetaData();
 
-    $this->assertEquals($a->image->alt, $image['alt'], 'Alt text correct.');
-    $this->assertEquals($a->image->title, $image['title'], 'Title text correct.');
-    $this->assertEquals($a->image->entity->url(), $image['entity']['url'], 'Retrieve correct image url.');
-    $imageStyle = ImageStyle::load('thumbnail');
-    $styleUrl = $imageStyle->buildUrl($a->image->entity->uri->value);
-    $this->assertEquals($styleUrl, $image['thumbnailImage']['url']);
+    $style = ImageStyle::load('thumbnail');
+
+    $dimensions = [
+      'width' => $a->image[0]->width,
+      'height' => $a->image[0]->height,
+    ];
+
+    $style->transformDimensions($dimensions, $a->image[0]->entity->getFileUri());
+
+    $metadata->addCacheTags([
+      'config:field.storage.node.body',
+      'config:field.storage.node.image',
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+      'file:1',
+      'node:1',
+      // TODO: missing image style config cache tags?
+    ]);
+
+    $this->assertResults($this->getQueryFromFile('image.gql'), [
+      'path' => '/node/' . $a->id(),
+    ], [
+      'route' => [
+        'node' => [
+          'image' => [[
+            'alt' => $a->image->alt,
+            'title' => $a->image->title,
+            'entity' => ['url' => $a->image->entity->url()],
+            'width' => $a->image[0]->width,
+            'height' => $a->image[0]->height,
+            'thumbnailImage' => [
+              'url' => $style->buildUrl($a->image->entity->uri->value),
+              'width' => $dimensions['width'],
+              'height' => $dimensions['height'],
+            ],
+          ]],
+        ],
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
@@ -44,7 +44,6 @@ class ImageFieldTest extends GraphQLContentTestBase {
 
     $a->save();
 
-    $metadata = $this->defaultCacheMetaData();
 
     $style = ImageStyle::load('thumbnail');
 
@@ -55,8 +54,9 @@ class ImageFieldTest extends GraphQLContentTestBase {
 
     $style->transformDimensions($dimensions, $a->image[0]->entity->getFileUri());
 
+    // TODO: Check cache metadata.
+    $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags([
-      'config:field.storage.node.body',
       'config:field.storage.node.image',
       'entity_bundles',
       'entity_field_info',

--- a/modules/graphql_core/tests/src/Kernel/Languages/LanguageTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Languages/LanguageTest.php
@@ -3,22 +3,20 @@
 namespace Drupal\Tests\graphql_core\Kernel\Languages;
 
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 
 /**
  * Test multilingual behavior of `graphql_core` features.
  *
  * @group graphql_core
  */
-class LanguageTest extends GraphQLTestBase {
+class LanguageTest extends GraphQLCoreTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
     'language',
-    'graphql',
-    'graphql_core',
     'graphql_context_test',
   ];
 
@@ -28,7 +26,6 @@ class LanguageTest extends GraphQLTestBase {
   protected function setUp() {
     parent::setUp();
 
-    $this->installEntitySchema('user');
     $this->installconfig(['language']);
     $this->installEntitySchema('configurable_language');
     $this->container->get('router.builder')->rebuild();
@@ -59,14 +56,8 @@ class LanguageTest extends GraphQLTestBase {
    * Test listing of available languages.
    */
   public function testLanguageId() {
-    $metadata = $this->defaultCacheMetaData();
-
     // TODO: Check cache metadata.
-    $metadata->addCacheTags([
-      'entity_bundles',
-      'entity_field_info',
-      'entity_types',
-    ]);
+    $metadata = $this->defaultCacheMetaData();
 
     $this->assertResults($this->getQueryFromFile('languages.gql'), [], [
       'languages' => [

--- a/modules/graphql_core/tests/src/Kernel/Languages/LanguageTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Languages/LanguageTest.php
@@ -3,26 +3,22 @@
 namespace Drupal\Tests\graphql_core\Kernel\Languages;
 
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\Tests\graphql\Traits\ProphesizePermissionsTrait;
-use Drupal\Tests\graphql\Traits\GraphQLFileTestTrait;
-use Drupal\Tests\language\Kernel\LanguageTestBase;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 
 /**
  * Test multilingual behavior of `graphql_core` features.
  *
  * @group graphql_core
  */
-class LanguageTest extends LanguageTestBase {
-  use GraphQLFileTestTrait;
-  use ProphesizePermissionsTrait;
+class LanguageTest extends GraphQLTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
+    'language',
     'graphql',
     'graphql_core',
-    'graphql_test',
     'graphql_context_test',
   ];
 
@@ -31,6 +27,9 @@ class LanguageTest extends LanguageTestBase {
    */
   protected function setUp() {
     parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installconfig(['language']);
     $this->installEntitySchema('configurable_language');
     $this->container->get('router.builder')->rebuild();
 
@@ -60,49 +59,57 @@ class LanguageTest extends LanguageTestBase {
    * Test listing of available languages.
    */
   public function testLanguageId() {
-    $result = $this->executeQueryFile('languages.gql');
+    $metadata = $this->defaultCacheMetaData();
 
-    $english = [
-      'id' => 'en',
-      'name' => 'English',
-      'isDefault' => TRUE,
-      'isLocked' => FALSE,
-      'direction' => 'ltr',
-      'weight' => 0,
-      'argument' => 'en',
-    ];
+    // TODO: Check cache metadata.
+    $metadata->addCacheTags([
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+    ]);
 
-    $french = [
-      'id' => 'fr',
-      'name' => 'French',
-      'isDefault' => FALSE,
-      'isLocked' => FALSE,
-      'direction' => 'ltr',
-      'weight' => 1,
-      'argument' => 'fr',
-    ];
+    $this->assertResults($this->getQueryFromFile('languages.gql'), [], [
+      'languages' => [
+        0 => [
+          'id' => 'en',
+          'name' => 'English',
+          'isDefault' => TRUE,
+          'isLocked' => FALSE,
+          'direction' => 'ltr',
+          'weight' => 0,
+          'argument' => 'en',
+        ],
 
-    $spanish = [
-      'id' => 'es',
-      'name' => 'Spanish',
-      'isDefault' => FALSE,
-      'isLocked' => FALSE,
-      'direction' => 'ltr',
-      'weight' => 2,
-      'argument' => 'es',
-    ];
+        1 => [
+          'id' => 'fr',
+          'name' => 'French',
+          'isDefault' => FALSE,
+          'isLocked' => FALSE,
+          'direction' => 'ltr',
+          'weight' => 1,
+          'argument' => 'fr',
+        ],
 
-    $brazil = [
-      'id' => 'pt-br',
-      'name' => 'Portuguese, Brazil',
-      'isDefault' => FALSE,
-      'isLocked' => FALSE,
-      'direction' => 'ltr',
-      'weight' => 3,
-      'argument' => 'pt_br',
-    ];
-
-    $this->assertEquals([$english, $french, $spanish, $brazil], $result['data']['languages']);
+        2 => [
+          'id' => 'es',
+          'name' => 'Spanish',
+          'isDefault' => FALSE,
+          'isLocked' => FALSE,
+          'direction' => 'ltr',
+          'weight' => 2,
+          'argument' => 'es',
+        ],
+        3 => [
+          'id' => 'pt-br',
+          'name' => 'Portuguese, Brazil',
+          'isDefault' => FALSE,
+          'isLocked' => FALSE,
+          'direction' => 'ltr',
+          'weight' => 3,
+          'argument' => 'pt_br',
+        ],
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
@@ -4,8 +4,7 @@ namespace Drupal\Tests\graphql_core\Kernel\Menu;
 
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
-use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @group graphql_menu
  */
-class MenuTest extends GraphQLTestBase {
+class MenuTest extends GraphQLCoreTestBase {
 
   /**
    * {@inheritdoc}
@@ -21,7 +20,6 @@ class MenuTest extends GraphQLTestBase {
   public static $modules = [
     'menu_link_content',
     'link',
-    'graphql_core',
     'graphql_test_menu',
   ];
 
@@ -30,7 +28,6 @@ class MenuTest extends GraphQLTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->installEntitySchema('user');
     $this->installEntitySchema('menu_link_content');
     $this->installConfig('menu_link_content');
     $this->installConfig('graphql_test_menu');
@@ -75,13 +72,10 @@ class MenuTest extends GraphQLTestBase {
    * Test menu tree data retrieval.
    */
   public function testMenuTree() {
+    // TODO: Check cache metadata.
     $metadata = $this->defaultCacheMetaData();
-
     $metadata->addCacheTags([
       'config:system.menu.test',
-      'entity_bundles',
-      'entity_field_info',
-      'entity_types',
     ]);
 
     $this->assertResults(
@@ -107,7 +101,7 @@ class MenuTest extends GraphQLTestBase {
                   'attribute' => NULL,
                   'route' => [
                     'path' => '/graphql/test/accessible',
-                    'routed' => true,
+                    'routed' => TRUE,
                   ],
                 ],
                 1 => [

--- a/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\graphql_core\Kernel\Menu;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -12,13 +13,12 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @group graphql_menu
  */
-class MenuTest extends GraphQLFileTestBase {
+class MenuTest extends GraphQLTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
-    'system',
     'menu_link_content',
     'link',
     'graphql_core',
@@ -30,6 +30,7 @@ class MenuTest extends GraphQLFileTestBase {
    */
   protected function setUp() {
     parent::setUp();
+    $this->installEntitySchema('user');
     $this->installEntitySchema('menu_link_content');
     $this->installConfig('menu_link_content');
     $this->installConfig('graphql_test_menu');
@@ -71,110 +72,76 @@ class MenuTest extends GraphQLFileTestBase {
   }
 
   /**
-   * Test if menu information is returned by GraphQL.
-   */
-  public function testMenuInfo() {
-    $result = $this->executeQueryFile('menu.gql');
-
-    $this->assertArrayHasKey('data', $result);
-
-    $this->assertArraySubset([
-      'info' => [
-        'name' => 'Test menu',
-        'description' => 'Menu for testing GraphQL menu access.',
-      ],
-    ], $result['data'], "Menu contains correct title and description.");
-  }
-
-  /**
    * Test menu tree data retrieval.
    */
   public function testMenuTree() {
+    $metadata = $this->defaultCacheMetaData();
 
-    $result = $this->executeQueryFile('menu.gql');
+    $metadata->addCacheTags([
+      'config:system.menu.test',
+      'entity_bundles',
+      'entity_field_info',
+      'entity_types',
+    ]);
 
-    $this->assertArrayHasKey('data', $result);
-
-    $this->assertArraySubset([
-      'menu' => [
-        'links' => [
-          0 => [
-            'label' => 'Accessible',
-            'route' => [
-              'path' => '/graphql/test/accessible',
-              'routed' => TRUE,
-            ],
-          ],
+    $this->assertResults(
+      $this->getQueryFromFile('menu.gql'),
+      [],
+      [
+        'info' => [
+          'name' => 'Test menu',
+          'description' => 'Menu for testing GraphQL menu access.',
         ],
-      ],
-    ], $result['data'], 'Accessible root item is returned.');
-
-    $this->assertArraySubset([
-      'menu' => [
-        'links' => [
-          0 => [
-            'links' => [
-              0 => [
-                'label' => 'Nested A',
-                'route' => [
-                  'path' => '/graphql/test/accessible',
-                  'routed' => TRUE,
+        'menu' => [
+          'links' => [
+            0 => [
+              'label' => 'Accessible',
+              'route' => [
+                'path' => '/graphql/test/accessible',
+                'routed' => TRUE,
+              ],
+              'attribute' => NULL,
+              'links' => [
+                0 => [
+                  'label' => 'Nested A',
+                  'attribute' => NULL,
+                  'route' => [
+                    'path' => '/graphql/test/accessible',
+                    'routed' => true,
+                  ],
+                ],
+                1 => [
+                  'label' => 'Nested B',
+                  'route' => [
+                    'path' => '/graphql/test/accessible',
+                    'routed' => TRUE,
+                  ],
+                  'attribute' => NULL,
                 ],
               ],
             ],
-          ],
-        ],
-      ],
-    ], $result['data'], 'Accessible nested item A is returned.');
-
-    $this->assertArraySubset([
-      'menu' => [
-        'links' => [
-          0 => [
-            'links' => [
-              1 => [
-                'label' => 'Nested B',
-                'route' => [
-                  'path' => '/graphql/test/accessible',
-                  'routed' => TRUE,
-                ],
+            1 => [
+              'label' => 'Inaccessible',
+              'route' => [
+                'path' => '/',
+                'routed' => TRUE,
               ],
+              'attribute' => NULL,
+              'links' => [],
+            ],
+            2 => [
+              'label' => 'Drupal',
+              'route' => [
+                'path' => 'http://www.drupal.org',
+                'routed' => FALSE,
+              ],
+              'attribute' => NULL,
+              'links' => [],
             ],
           ],
         ],
       ],
-    ], $result['data'], 'Accessible nested item B is returned.');
-
-    $this->assertArraySubset([
-      'menu' => [
-        'links' => [
-          1 => [
-            'label' => 'Inaccessible',
-            'route' => [
-              'path' => '/',
-              'routed' => TRUE,
-            ],
-          ],
-        ],
-      ],
-    ], $result['data'], 'Inaccessible root item is obfuscated.');
-
-    $inaccessibleChildren = $result['data']['menu']['links'][1]['links'];
-    $this->assertEmpty($inaccessibleChildren, 'Inaccessible items do not expose children.');
-
-    $this->assertArraySubset([
-      'menu' => [
-        'links' => [
-          2 => [
-            'label' => 'Drupal',
-            'route' => [
-              'path' => 'http://www.drupal.org',
-              'routed' => FALSE,
-            ],
-          ],
-        ],
-      ],
-    ], $result['data'], 'External menu link is included properly.');
+      $metadata
+    );
   }
-
 }

--- a/modules/graphql_core/tests/src/Kernel/Routing/ExternalRequestTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Routing/ExternalRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Routing;
 
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
 
@@ -11,12 +11,20 @@ use GuzzleHttp\Psr7\Response;
  *
  * @group graphql_core
  */
-class ExternalRequestTest extends GraphQLFileTestBase {
+class ExternalRequestTest extends GraphQLCoreTestBase {
 
   /**
    * {@inheritdoc}
    */
   public static $modules = ['graphql_core'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+  }
 
   /**
    * Test external requests.
@@ -32,11 +40,19 @@ class ExternalRequestTest extends GraphQLFileTestBase {
 
     $this->container->set('http_client', $client->reveal());
 
-    $result = $this->executeQueryFile('external_requests.gql', [], TRUE, TRUE);
+    // TODO: Check cache metadata.
+    // Add cache information from external response?
+    $metadata = $this->defaultCacheMetaData();
 
-    $this->assertEquals(200, $result['data']['route']['request']['code']);
-    $this->assertContains('<p>GraphQL is awesome!</p>', $result['data']['route']['request']['content']);
-    $this->assertEquals('test', $result['data']['route']['request']['header']);
+    $this->assertResults($this->getQueryFromFile('external_requests.gql'), [], [
+      'route' => [
+        'request' => [
+          'code' => 200,
+          'content' => '<p>GraphQL is awesome!</p>',
+          'header' => 'test',
+        ],
+      ],
+    ], $metadata);
   }
 
 }

--- a/modules/graphql_core/tests/src/Kernel/Routing/InternalRequestTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Routing/InternalRequestTest.php
@@ -2,31 +2,49 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\Routing;
 
-use Drupal\Tests\graphql\Kernel\GraphQLFileTestBase;
+use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 
 /**
  * Test internal requests.
  *
  * @group graphql_core
  */
-class InternalRequestTest extends GraphQLFileTestBase {
+class InternalRequestTest extends GraphQLCoreTestBase {
 
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['graphql_requests_test', 'graphql_core'];
+  public static $modules = ['graphql_core', 'graphql_requests_test'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+  }
 
   /**
    * Test internal requests.
    */
   public function testInternalRequests() {
-    $result = $this->executeQueryFile('internal_requests.gql');
+    // TODO: Check cache metadata.
+    $metadata = $this->defaultCacheMetaData();
 
-    $this->assertEquals(200, $result['data']['ok']['request']['code']);
-    $this->assertContains('<p>Test</p>', $result['data']['ok']['request']['content']);
-
-    $this->assertEquals(302, $result['data']['redirect']['request']['code']);
-    $this->assertEquals('/graphql-request/test', $result['data']['redirect']['request']['location']);
+    $this->assertResults($this->getQueryFromFile('internal_requests.gql'), [], [
+      'ok' => [
+        'request' => [
+          'code' => 200,
+          'content' => '<p>Test</p>',
+        ],
+      ],
+      'redirect' => [
+        'request' => [
+          'code' => 302,
+          'location' => '/graphql-request/test',
+        ],
+      ],
+    ], $metadata);
   }
 
 }

--- a/src/Annotation/GraphQLAnnotationBase.php
+++ b/src/Annotation/GraphQLAnnotationBase.php
@@ -85,7 +85,7 @@ abstract class GraphQLAnnotationBase extends Plugin {
    *
    * @var array
    */
-  public $response_cache_contexts = ['user'];
+  public $response_cache_contexts = ['user.permissions'];
 
   /**
    * The cache tags for caching theresponse.

--- a/src/Plugin/GraphQL/Traits/CacheablePluginTrait.php
+++ b/src/Plugin/GraphQL/Traits/CacheablePluginTrait.php
@@ -42,7 +42,7 @@ trait CacheablePluginTrait {
   public function getResponseCacheMetadata() {
     $definition = $this->getPluginDefinition();
     $metadata = new CacheableMetadata();
-    $metadata->addCacheContexts(isset($definition['response_cache_contexts']) ? $definition['response_cache_contexts'] : ['user']);
+    $metadata->addCacheContexts(isset($definition['response_cache_contexts']) ? $definition['response_cache_contexts'] : ['user.permissions']);
     $metadata->addCacheTags(isset($definition['response_cache_tags']) ? $definition['response_cache_tags'] : []);
     $metadata->setCacheMaxAge(isset($definition['response_cache_max_age']) ? $definition['response_cache_max_age'] : CacheBackendInterface::CACHE_PERMANENT);
     return $metadata;

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -32,6 +32,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
    */
   public static $modules = [
     'system',
+    'user',
     'graphql',
   ];
 
@@ -73,7 +74,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
    * {@inheritdoc}
    */
   protected function defaultCacheContexts() {
-    return ['gql', 'languages:language_interface', 'user'];
+    return ['gql', 'languages:language_interface', 'user.permissions'];
   }
 
   /**

--- a/tests/src/Traits/ProphesizePermissionsTrait.php
+++ b/tests/src/Traits/ProphesizePermissionsTrait.php
@@ -38,9 +38,9 @@ trait ProphesizePermissionsTrait {
     $permissions = $this->userPermissions();
 
     $user
-      ->hasPermission(Argument::type('string'))
+      ->hasPermission(Argument::type('string'), Argument::cetera())
       ->will(function ($args) use ($permissions) {
-        return AccessResult::allowedIf(in_array($args[0], $permissions));
+        return in_array($args[0], $permissions);
       });
 
     $user->id()->willReturn(0);

--- a/tests/src/Traits/ProphesizePermissionsTrait.php
+++ b/tests/src/Traits/ProphesizePermissionsTrait.php
@@ -35,10 +35,13 @@ trait ProphesizePermissionsTrait {
     // Replace the current user with a prophecy that has the defined
     // permissions.
     $user = $this->prophesize(AccountProxyInterface::class);
+    $permissions = $this->userPermissions();
 
-    $user->hasPermission(Argument::that(function ($arg) {
-      return in_array($arg, $this->userPermissions());
-    }))->willReturn(AccessResult::allowed());
+    $user
+      ->hasPermission(Argument::type('string'))
+      ->will(function ($args) use ($permissions) {
+        return AccessResult::allowedIf(in_array($args[0], $permissions));
+      });
 
     $user->id()->willReturn(0);
     $user->isAnonymous()->willReturn(TRUE);

--- a/tests/src/Traits/ProphesizePermissionsTrait.php
+++ b/tests/src/Traits/ProphesizePermissionsTrait.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\graphql\Traits;
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountProxyInterface;
 use Prophecy\Argument;
 
@@ -27,6 +26,15 @@ trait ProphesizePermissionsTrait {
   }
 
   /**
+   * Set the prophesized roles.
+   *
+   * @return string[]
+   */
+  protected function userRoles() {
+    return ['anonymous'];
+  }
+
+  /**
    * Bypass user access.
    *
    * @before
@@ -42,6 +50,10 @@ trait ProphesizePermissionsTrait {
       ->will(function ($args) use ($permissions) {
         return in_array($args[0], $permissions);
       });
+
+    $user
+      ->getRoles(Argument::any())
+      ->willReturn($this->userRoles());
 
     $user->id()->willReturn(0);
     $user->isAnonymous()->willReturn(TRUE);

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -163,7 +163,17 @@ trait QueryResultAssertionTrait {
       $expected = new CacheableMetadata();
     }
     $this->assertEquals($expected->getCacheMaxAge(), $result->getCacheMaxAge(), 'Unexpected cache max age.');
-    $this->assertEquals($expected->getCacheContexts(), $result->getCacheContexts(), 'Unexpected cache contexts.');
-    $this->assertEquals($expected->getCacheTags(), $result->getCacheTags(), 'Unexpected cache tags.');
+
+    $missingContexts = array_diff($expected->getCacheContexts(), $result->getCacheContexts());
+    $this->assertEmpty($missingContexts, 'Missing cache contexts: ' . implode(', ', $missingContexts));
+
+    $unexpectedContexts = array_diff($result->getCacheContexts(), $expected->getCacheContexts());
+    $this->assertEmpty($unexpectedContexts, 'Unexpected cache contexts: ' . implode(', ', $unexpectedContexts));
+
+    $missingTags = array_diff($expected->getCacheTags(), $result->getCacheTags());
+    $this->assertEmpty($missingTags, 'Missing cache tags: '  . implode(', ', $missingTags));
+
+    $unexpectedTags = array_diff($result->getCacheTags(), $expected->getCacheTags());
+    $this->assertEmpty($unexpectedTags, 'Unexpected cache tags: ' . implode(', ', $unexpectedTags));
   }
 }


### PR DESCRIPTION
I moved all `graphql_core` tests to the new test structure and added cache metadata assertions.
All occasions are marked with a `//TODO: Check cache metadata.`, since to this step i just made sure the tests are green. We should double-check all cache metadata assertions and make sure they are correct.

Additionally i fixed the `user`  vs. `user.permissions` cache tag issue and improved cache metadata assertion reporting.