### PR TITLE
docs(graphql): Start working on gitbook doc structure

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,47 +1,45 @@
 # GraphQL for Drupal
 
-This module lets you craft and expose a [GraphQL] schema for [Drupal 8].
+This module lets you craft and expose a [GraphQL](http://graphql.org/) schema for [Drupal 8](https://www.drupal.org/8).
 
-It is is built around https://github.com/Youshido/GraphQL. As such, it supports
+It is is built around [https://github.com/Youshido/GraphQL](https://github.com/Youshido/GraphQL). As such, it supports  
 the full official GraphQL specification with all its features.
 
-You can use this module as a foundation for building your own schema through
-custom code or you can use and extend the generated schema using the plugin
+You can use this module as a foundation for building your own schema through  
+custom code or you can use and extend the generated schema using the plugin  
 architecture and the provided plugin implementations form the sub-module.
 
-For ease of development, it includes the [GraphiQL] interface at
+For ease of development, it includes the [GraphiQL](https://github.com/graphql/graphiql/) interface at  
 /graphql/explorer.
-
-[Drupal 8]: https://www.drupal.org/8
-[GraphQL]: http://graphql.org/
-[GraphiQL]: https://github.com/graphql/graphiql/
 
 ## Example implementation
 
-Check out https://github.com/fubhy/drupal-decoupled-app for a complete example
-of a fully decoupled React and GraphQL application. Feel free to use that
+Check out [https://github.com/fubhy/drupal-decoupled-app](https://github.com/fubhy/drupal-decoupled-app) for a complete example  
+of a fully decoupled React and GraphQL application. Feel free to use that  
 repository as a starting point for your own decoupled application.
 
 ## Documentation
 
-Please note that our documentation is outdated and in dire need of rewriting.
-This is due to the vast amount of improvements and additional features we've
-added to the module recently. As we are finishing up the 3.x version of this
+Please note that our documentation is outdated and in dire need of rewriting.  
+This is due to the vast amount of improvements and additional features we've  
+added to the module recently. As we are finishing up the 3.x version of this  
 module we will be re-doing the documentation and record a series of screencasts.
 
-In the meantime, you can refer to these blog posts to learn more about how the
+In the meantime, you can refer to these blog posts to learn more about how the  
 module works and how you can configure, adjust and extend it:
 
-* https://www.amazeelabs.com/en/blog/graphql-introduction
-* https://www.amazeelabs.com/en/blog/drupal-graphql-react-apollo
-* https://www.amazeelabs.com/en/blog/drupal-graphql-batteries-included
-* https://www.amazeelabs.com/en/blog/extending-graphql-part1-fields
-* https://www.amazeelabs.com/en/blog/extending-graphql-part-2
-* https://www.amazeelabs.com/en/blog/graphql-for-drupalers-fields
-* https://www.amazeelabs.com/en/blog/extending-graphql-part-3-mutations
+* [https://www.amazeelabs.com/en/blog/graphql-introduction](https://www.amazeelabs.com/en/blog/graphql-introduction)
+* [https://www.amazeelabs.com/en/blog/drupal-graphql-react-apollo](https://www.amazeelabs.com/en/blog/drupal-graphql-react-apollo)
+* [https://www.amazeelabs.com/en/blog/drupal-graphql-batteries-included](https://www.amazeelabs.com/en/blog/drupal-graphql-batteries-included)
+* [https://www.amazeelabs.com/en/blog/extending-graphql-part1-fields](https://www.amazeelabs.com/en/blog/extending-graphql-part1-fields)
+* [https://www.amazeelabs.com/en/blog/extending-graphql-part-2](https://www.amazeelabs.com/en/blog/extending-graphql-part-2)
+* [https://www.amazeelabs.com/en/blog/graphql-for-drupalers-fields](https://www.amazeelabs.com/en/blog/graphql-for-drupalers-fields)
+* [https://www.amazeelabs.com/en/blog/extending-graphql-part-3-mutations](https://www.amazeelabs.com/en/blog/extending-graphql-part-3-mutations)
 
 ## Resources
- 
-* Project homepage: https://www.drupal.org/project/graphql
-* Contributing: https://github.com/fubhy/graphql-drupal
+
+* Project homepage: [https://www.drupal.org/project/graphql](https://www.drupal.org/project/graphql)
+* Contributing: [https://github.com/fubhy/graphql-drupal](https://github.com/fubhy/graphql-drupal)
+
+
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -17,3 +17,7 @@
 * [Introduction](mutations/readme.md)
 * [Creating mutation plugins](mutations/creating-mutation-plugins.md)
 
+## Authentication
+
+* [Introduction](authentication/introduction.md)
+

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+* [Introduction](README.md)
+
+## Queries
+
+* [Introduction](queries/readme.md)
+
+## Mutations
+
+* [Introduction](mutations/readme.md)
+

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -9,8 +9,11 @@
 ## Queries
 
 * [Introduction](queries/readme.md)
+* [Querying nodes](queries/querying-nodes.md)
+* [Querying taxonomies](queries/querying-taxonomies.md)
 
 ## Mutations
 
 * [Introduction](mutations/readme.md)
+* Creating mutation plugins
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -2,6 +2,10 @@
 
 * [Introduction](README.md)
 
+## Getting started
+
+* [Getting started](getting-started/readme.md)
+
 ## Queries
 
 * [Introduction](queries/readme.md)

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -15,5 +15,5 @@
 ## Mutations
 
 * [Introduction](mutations/readme.md)
-* Creating mutation plugins
+* [Creating mutation plugins](mutations/creating-mutation-plugins.md)
 

--- a/doc/authentication/introduction.md
+++ b/doc/authentication/introduction.md
@@ -1,0 +1,2 @@
+Explain the basics of how authentication work in graphql + drupal
+

--- a/doc/getting-started/readme.md
+++ b/doc/getting-started/readme.md
@@ -1,0 +1,10 @@
+# GraphQL for Drupal
+
+This module lets you craft and expose a [GraphQL](http://graphql.org/) schema for [Drupal 8](https://www.drupal.org/8).
+
+It is is built around [https://github.com/Youshido/GraphQL](https://github.com/Youshido/GraphQL). As such, it supports  
+the full official GraphQL specification with all its features.
+
+You can use this module as a foundation for building your own schema through  
+custom code or you can use and extend the generated schema using the plugin  
+architecture and the provided plugin implementations form the sub-module.

--- a/doc/mutations/creating-mutation-plugins.md
+++ b/doc/mutations/creating-mutation-plugins.md
@@ -1,0 +1,2 @@
+Creating mutation plugins
+

--- a/doc/mutations/readme.md
+++ b/doc/mutations/readme.md
@@ -1,0 +1,1 @@
+Explain how mutations work

--- a/doc/queries/querying-nodes.md
+++ b/doc/queries/querying-nodes.md
@@ -1,0 +1,2 @@
+How one can use the nodeQuery
+

--- a/doc/queries/querying-taxonomies.md
+++ b/doc/queries/querying-taxonomies.md
@@ -1,0 +1,2 @@
+How one can use the taxonomyQuery
+

--- a/doc/queries/readme.md
+++ b/doc/queries/readme.md
@@ -1,0 +1,2 @@
+Explain how queries work
+


### PR DESCRIPTION
Getting started with some basic doc structure. I guess we can then split each of these ones into smaller pieces.but it should be a good starting point.

The initial structure would look like this : 

## Getting started

* [Getting started]

## Queries

* [Introduction]
* [Querying nodes]
* [Querying taxonomies]

## Mutations

* [Introduction]
* [Creating mutation plugins]

## Authentication

* [Introduction]

Then I would think different PR's for different parts would probably be the easiest way for diff people to contribute?