### PR TITLE
Resolving Interface/Type naming conflicts.

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/Types/EntityBundleDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Types/EntityBundleDeriver.php
@@ -68,7 +68,7 @@ class EntityBundleDeriver extends DeriverBase implements ContainerDeriverInterfa
       }
 
       // Only create a bundle type for entity types that support bundles.
-      if (!$type->hasKey('bundle')) {
+      if (!$type->hasKey('bundle') || !array_key_exists($typeId, $bundles)) {
         continue;
       }
 

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityPropertyConflict.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityPropertyConflict.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\Tests\graphql_core\Kernel\Entity;
+
+use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
+
+/**
+ * Test entity property naming conflict resolution.
+ *
+ * @group graphql_core
+ */
+class EntityPropertyConflict extends GraphQLContentTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'comment',
+  ];
+
+  /**
+   * Check proper behavior in case of a naming conflict.
+   */
+  public function testNamingConflict() {
+    $this->assertGraphQLFields([
+      ['Comment', 'entityId', 'String'],
+      ['Comment', 'entityIdOfComment', 'FieldCommentEntityId'],
+    ]);
+  }
+
+}

--- a/src/Plugin/Deriver/PluggableSchemaDeriver.php
+++ b/src/Plugin/Deriver/PluggableSchemaDeriver.php
@@ -217,11 +217,11 @@ class PluggableSchemaDeriver extends DeriverBase implements ContainerDeriverInte
    */
   protected function buildFieldAssociationMap(FieldPluginManager $manager, $types) {
     $definitions = $manager->getDefinitions();
-    $fields = array_reduce(array_keys($definitions), function ($carry, $id) use ($definitions) {
+    $fields = array_reduce(array_keys($definitions), function ($carry, $id) use ($definitions, $types) {
       $current = $definitions[$id];
       $parents = $current['parents'] ?: ['Root'];
 
-      return array_reduce($parents, function ($carry, $parent) use ($current, $id) {
+      return array_reduce($parents, function ($carry, $parent) use ($current, $id, $types) {
         // Allow plugins to define a different name for each parent.
         if (strpos($parent, ':') !== FALSE) {
           list($parent, $name) = explode(':', $parent);
@@ -238,6 +238,28 @@ class PluggableSchemaDeriver extends DeriverBase implements ContainerDeriverInte
         return $carry;
       }, $carry);
     }, []);
+
+    $rename = [];
+
+    foreach ($fields as $parent => $fieldList) {
+      foreach ($fieldList as $field => $info) {
+        if (!array_key_exists($parent, $types)) {
+          continue;
+        }
+        foreach ($types[$parent]['definition']['interfaces'] as $interface) {
+          if (isset($fields[$interface][$field]) && $fields[$interface][$field]['id'] != $info['id']) {
+            $rename[$parent][$field] = TRUE;
+          }
+        }
+      }
+    }
+
+    foreach ($rename as $parent => $names) {
+      foreach (array_keys($names) as $name) {
+        $fields[$parent][$name . 'Of' . $parent] = $fields[$parent][$name];
+        unset($fields[$parent][$name]);
+      }
+    }
 
     // Only return fields for types that are actually fieldable.
     $fieldable = [GRAPHQL_TYPE_PLUGIN, GRAPHQL_INTERFACE_PLUGIN];

--- a/src/Plugin/Deriver/PluggableSchemaDeriver.php
+++ b/src/Plugin/Deriver/PluggableSchemaDeriver.php
@@ -247,7 +247,7 @@ class PluggableSchemaDeriver extends DeriverBase implements ContainerDeriverInte
           continue;
         }
         foreach ($types[$parent]['definition']['interfaces'] as $interface) {
-          if (isset($fields[$interface][$field]) && $fields[$interface][$field]['id'] != $info['id']) {
+          if (isset($fields[$interface][$field]) && $definitions[$fields[$interface][$field]['id']]['type'] != $definitions[$info['id']]['type']) {
             $rename[$parent][$field] = TRUE;
           }
         }


### PR DESCRIPTION
Rename conflicting fields to `[field]Of[parent]`. For example `entityId` on `Comment` becomes `entityIdOfComment` to avoid the conflict with `entityId` on the `Entity` interface. 