### PR TITLE
WIP: Respect "isInternal"

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/EntityFieldDeriverBase.php
+++ b/modules/graphql_core/src/Plugin/Deriver/EntityFieldDeriverBase.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\TypedData\DataDefinitionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,6 +24,8 @@ abstract class EntityFieldDeriverBase extends DeriverBase implements ContainerDe
    *
    * @param string $entityTypeId
    *   The host entity type.
+   * @param string $bundle
+   *   The host bundle.
    * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $fieldDefinition
    *   Field definition object.
    * @param array $basePluginDefinition
@@ -31,7 +34,7 @@ abstract class EntityFieldDeriverBase extends DeriverBase implements ContainerDe
    * @return array
    *   The derived plugin definitions for the given field.
    */
-  abstract protected function getDerivativeDefinitionsFromFieldDefinition($entityTypeId, FieldStorageDefinitionInterface $fieldDefinition, array $basePluginDefinition);
+  abstract protected function getDerivativeDefinitionsFromFieldDefinition($entityTypeId, $bundle, FieldStorageDefinitionInterface $fieldDefinition, array $basePluginDefinition);
 
   /**
    * The entity type manager.
@@ -114,6 +117,21 @@ abstract class EntityFieldDeriverBase extends DeriverBase implements ContainerDe
     }
 
     return $this->derivatives;
+  }
+
+  /**
+   * Get accessible (non-internal) properties of a field.
+   *
+   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $fieldStorageDefinition
+   *   The field storage definition.
+   *
+   * @return DataDefinitionInterface[]
+   *   The property data definitions.
+   */
+  protected function getAccessiblePropertyDefinitions(FieldStorageDefinitionInterface $fieldStorageDefinition) {
+    return array_filter($fieldStorageDefinition->getPropertyDefinitions(), function (DataDefinitionInterface $definition) {
+      return !method_exists($definition, 'isInternal') || !$definition->isInternal();
+    });
   }
 
 }

--- a/modules/graphql_core/src/Plugin/Deriver/EntityTypeDeriverBase.php
+++ b/modules/graphql_core/src/Plugin/Deriver/EntityTypeDeriverBase.php
@@ -65,4 +65,17 @@ abstract class EntityTypeDeriverBase extends DeriverBase implements ContainerDer
     return array_unique($interfaces);
   }
 
+  /**
+   * Check if an entity type is accessible.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $type
+   *   The entity type to check.
+   *
+   * @return bool
+   *   TRUE if the type is not internal.
+   */
+  public static function isAccessibleEntityType(EntityTypeInterface $type) {
+    return !method_exists($type, 'isInternal' || !$type->isInternal());
+  }
+
 }

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityByIdDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityByIdDeriver.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityByIdDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -43,7 +44,7 @@ class EntityByIdDeriver extends DeriverBase implements ContainerDeriverInterface
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $id => $type) {
-      if ($type instanceof ContentEntityTypeInterface) {
+      if ($type instanceof ContentEntityTypeInterface && EntityTypeDeriverBase::isAccessibleEntityType($type)) {
         $derivative = [
           'name' => StringHelper::propCase($id, 'by', 'id'),
           'type' => "entity:$id",

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
@@ -13,7 +13,7 @@ class EntityFieldDeriver extends EntityFieldDeriverBase {
    * {@inheritdoc}
    */
   protected function getDerivativeDefinitionsFromFieldDefinition($entityTypeId, FieldStorageDefinitionInterface $fieldDefinition, array $basePluginDefinition) {
-    if (!$propertyDefinitions = $fieldDefinition->getPropertyDefinitions()) {
+    if (!$propertyDefinitions = $this->getAccessiblePropertyDefinitions($fieldDefinition)) {
       return [];
     }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldItemDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldItemDeriver.php
@@ -14,7 +14,7 @@ class EntityFieldItemDeriver extends EntityFieldDeriverBase {
    * {@inheritdoc}
    */
   protected function getDerivativeDefinitionsFromFieldDefinition($entityTypeId, FieldStorageDefinitionInterface $fieldDefinition, array $basePluginDefinition, $bundleId = NULL) {
-    if (!$propertyDefinitions = $fieldDefinition->getPropertyDefinitions()) {
+    if (!$propertyDefinitions = $this->getAccessiblePropertyDefinitions($fieldDefinition)) {
       return [];
     }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldPropertyDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldPropertyDeriver.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityFieldPropertyDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -59,7 +60,7 @@ class EntityFieldPropertyDeriver extends DeriverBase implements ContainerDeriver
     $parents = [];
     foreach ($this->entityTypeManager->getDefinitions() as $entityTypeId => $entityType) {
       $interfaces = class_implements($entityType->getClass());
-      if (!array_key_exists(FieldableEntityInterface::class, $interfaces)) {
+      if (!array_key_exists(FieldableEntityInterface::class, $interfaces) || !EntityTypeDeriverBase::isAccessibleEntityType($entityType)) {
         continue;
       }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityQueryDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityQueryDeriver.php
@@ -9,6 +9,7 @@ use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TypedData\TypedDataManager;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityQueryDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -59,7 +60,7 @@ class EntityQueryDeriver extends DeriverBase implements ContainerDeriverInterfac
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $id => $type) {
-      if ($type instanceof ContentEntityTypeInterface) {
+      if ($type instanceof ContentEntityTypeInterface && EntityTypeDeriverBase::isAccessibleEntityType($type)) {
         $derivative = [
           'name' => StringHelper::propCase($id, 'query'),
           'description' => $this->t("Loads '@type' entities.", ['@type' => $type->getLabel()]),

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityReferenceReverseDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityReferenceReverseDeriver.php
@@ -11,6 +11,7 @@ use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TypedData\TypedDataManagerInterface;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityReferenceReverseDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -74,7 +75,7 @@ class EntityReferenceReverseDeriver extends DeriverBase implements ContainerDeri
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $entityTypeId => $entityType) {
       $interfaces = class_implements($entityType->getClass());
-      if (!array_key_exists(FieldableEntityInterface::class, $interfaces)) {
+      if (!array_key_exists(FieldableEntityInterface::class, $interfaces) || !EntityTypeDeriverBase::isAccessibleEntityType($entityType)) {
         continue;
       }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRenderedDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRenderedDeriver.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityRenderedDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -42,7 +43,7 @@ class EntityRenderedDeriver extends DeriverBase implements ContainerDeriverInter
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $id => $type) {
-      if ($type instanceof ContentEntityTypeInterface) {
+      if ($type instanceof ContentEntityTypeInterface && EntityTypeDeriverBase::isAccessibleEntityType($type)) {
         $derivative = [
           'parents' => [StringHelper::camelCase($id)],
           'description' => $this->t("Renders '@type' entities in the given view mode.", ['@type' => $type->getLabel()]),

--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRevisionByIdDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRevisionByIdDeriver.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityRevisionByIdDeriver extends DeriverBase implements ContainerDeriverInterface {
@@ -43,7 +44,7 @@ class EntityRevisionByIdDeriver extends DeriverBase implements ContainerDeriverI
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $id => $type) {
-      if ($type instanceof ContentEntityTypeInterface && $type->isRevisionable()) {
+      if ($type instanceof ContentEntityTypeInterface && $type->isRevisionable() && EntityTypeDeriverBase::isAccessibleEntityType($type)) {
         $derivative = [
           'name' => StringHelper::propCase($id, 'revision', 'by', 'id'),
           'type' => "entity:$id",

--- a/modules/graphql_core/src/Plugin/Deriver/Interfaces/EntityTypeDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Interfaces/EntityTypeDeriver.php
@@ -15,7 +15,7 @@ class EntityTypeDeriver extends EntityTypeDeriverBase {
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $typeId => $type) {
-      if (!($type instanceof ContentEntityTypeInterface)) {
+      if (!($type instanceof ContentEntityTypeInterface || !static::isAccessibleEntityType($type))) {
         continue;
       }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Types/EntityBundleDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Types/EntityBundleDeriver.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityTypeDeriverBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -63,7 +64,7 @@ class EntityBundleDeriver extends DeriverBase implements ContainerDeriverInterfa
   public function getDerivativeDefinitions($basePluginDefinition) {
     $bundles = $this->entityTypeBundleInfo->getAllBundleInfo();
     foreach ($this->entityTypeManager->getDefinitions() as $typeId => $type) {
-      if (!($type instanceof ContentEntityTypeInterface)) {
+      if (!($type instanceof ContentEntityTypeInterface && EntityTypeDeriverBase::isAccessibleEntityType($type))) {
         continue;
       }
 

--- a/modules/graphql_core/src/Plugin/Deriver/Types/EntityFieldTypeDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Types/EntityFieldTypeDeriver.php
@@ -16,7 +16,7 @@ class EntityFieldTypeDeriver extends EntityFieldDeriverBase {
    */
   protected function getDerivativeDefinitionsFromFieldDefinition($entityTypeId, FieldStorageDefinitionInterface $fieldDefinition, array $basePluginDefinition) {
     // Only create a type for fields with at least two properties.
-    $propertyDefinitions = $fieldDefinition->getPropertyDefinitions();
+    $propertyDefinitions = $this->getAccessiblePropertyDefinitions($fieldDefinition);
     if (count($propertyDefinitions) <= 1) {
       return [];
     }

--- a/modules/graphql_core/src/Plugin/Deriver/Types/EntityTypeDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Types/EntityTypeDeriver.php
@@ -15,7 +15,7 @@ class EntityTypeDeriver extends EntityTypeDeriverBase {
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $typeId => $type) {
-      if (!($type instanceof ContentEntityTypeInterface)) {
+      if (!($type instanceof ContentEntityTypeInterface && $this->isAccessibleEntityType($type))) {
         continue;
       }
 


### PR DESCRIPTION
A first attempt to resolve #429.

Derivers respect `isInternal` on entity types and property definitions. I did not yet have time to do the same for fields, because we are deriving based on field storage definitions, and not on field definitions (which carry the `isInternal` information). So we would have to turn the deriver strategy upside down.

But even without correct internal field definitions, problems surface. Currently a lot of field properties that are heavily used get stripped out. Like the entity-property on any entity reference or the processed summary text of a long text field.

GraphQL is a notch more internal than REST and JSONAPI, since it requires some degree of control over the client application (e.g. by using persisted queries), and I'm not sure all fields marked as internal apply to this case. If we blindly do this, we shred every project that has ever been built on the GraphQL module. And we would have to re-create a lot of the lost references artificially.