### PR TITLE
Ctrl-Space does not work on Mac

### DIFF
--- a/doc/getting-started/readme.md
+++ b/doc/getting-started/readme.md
@@ -40,7 +40,7 @@ http://graphql.org/learn/
      }
      ```
 
-5. Press `Ctrl-Space` and you should see something like the following display in the right pane: 
+5. Press `Ctrl-Space` or `Ctrl-Enter` (Mac) and you should see something like the following display in the right pane: 
     
     ```json
     {


### PR DESCRIPTION
I use Firefox on MacOS and `Ctrl-Space` does not work. `Ctrl-Enter` does work.