### PR TITLE
Add RevisionMode LATEST and handle it in EntityQuery

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Enums/EntityQuery/EntityQueryRevisionMode.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Enums/EntityQuery/EntityQueryRevisionMode.php
@@ -16,6 +16,10 @@ use Drupal\graphql\Plugin\GraphQL\Enums\EnumPluginBase;
  *     "ALL" = {
  *       "value" = "all",
  *       "description" = @Translation("Loads all revisions."),
+ *     },
+ *     "LATEST" = {
+ *       "value" = "latest",
+ *       "description" = @Translation("Loads latest revision."),
  *     }
  *   }
  * )

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
@@ -228,6 +228,11 @@ class EntityQuery extends FieldPluginBase implements ContainerFactoryPluginInter
       $query->allRevisions();
       $query->addTag('revisions');
     }
+    else if ($mode === 'latest') {
+      // Mark the query to only include latest revision and sort by revision id.
+      $query->latestRevision();
+      $query->addTag('revisions');
+    }
 
     return $query;
   }


### PR DESCRIPTION
As EntityQuery provides the latestRevision() method, it seems to be straight forward to add support for it to the GraphQL module.

See Drupal change records:
https://www.drupal.org/node/2918184

See latestRevision Documentation:
https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21Query%21QueryInterface.php/function/QueryInterface%3A%3AlatestRevision/8.5.x

Any feedback is very welcome :)

Thanks and best,
Walter