### PR TITLE
Use languageManager to check first for multilingual configuration in route field resolver

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Routing/Route.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Routing/Route.php
@@ -8,6 +8,7 @@ use Drupal\graphql\GraphQL\Cache\CacheableValue;
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
 use Drupal\language\LanguageNegotiator;
+use Drupal\Core\Language\LanguageManagerInterface;
 use GraphQL\Type\Definition\ResolveInfo;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -43,6 +44,13 @@ class Route extends FieldPluginBase implements ContainerFactoryPluginInterface {
   protected $languageNegotiator;
 
   /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -51,7 +59,8 @@ class Route extends FieldPluginBase implements ContainerFactoryPluginInterface {
       $plugin_id,
       $plugin_definition,
       $container->get('path.validator'),
-      $container->has('language_negotiator') ? $container->get('language_negotiator') : NULL
+      $container->has('language_negotiator') ? $container->get('language_negotiator') : NULL,
+      $container->get('language_manager')
     );
   }
 
@@ -68,17 +77,21 @@ class Route extends FieldPluginBase implements ContainerFactoryPluginInterface {
    *   The path validator service.
    * @param \Drupal\language\LanguageNegotiator|null $languageNegotiator
    *   The language negotiator.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
    */
   public function __construct(
     array $configuration,
     $pluginId,
     $pluginDefinition,
     PathValidatorInterface $pathValidator,
-    $languageNegotiator
+    $languageNegotiator,
+    $languageManager
   ) {
     parent::__construct($configuration, $pluginId, $pluginDefinition);
     $this->pathValidator = $pathValidator;
     $this->languageNegotiator = $languageNegotiator;
+    $this->languageManager = $languageManager;
   }
 
   /**
@@ -91,7 +104,7 @@ class Route extends FieldPluginBase implements ContainerFactoryPluginInterface {
    */
   public function resolve($value, array $args, ResolveContext $context, ResolveInfo $info) {
     // For now we just take the "url" negotiator into account.
-    if ($this->languageNegotiator) {
+    if ($this->languageManager->isMultilingual() && $this->languageNegotiator) {
       if ($negotiator = $this->languageNegotiator->getNegotiationMethodInstance('language-url')) {
         $context->setContext('language', $negotiator->getLangcode(Request::create($args['path'])), $info);
       }


### PR DESCRIPTION
As a followup from #604 here's an alternative approach to skip the language negotiation checks on monolingual (non-multilingual) sites in the `route` field resolver.