### PR TITLE
Fixes webonyx/graphql-php link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This module lets you craft and expose a [GraphQL](http://graphql.org/) schema for [Drupal 8](https://www.drupal.org/8).
 
-It is is built around [https://github.com/webonyx/graphql-php](webonyx/graphql-php). As such, it supports
+It is is built around [https://github.com/webonyx/graphql-php](https://github.com/webonyx/graphql-php). As such, it supports
 the full official GraphQL specification with all its features.
 
 You can use this module as a foundation for building your own schema through


### PR DESCRIPTION
Was browsing the repo and saw that the link to webonyx/graphql-php in the README is a relative link that points to `https://github.com/drupal-graphql/graphql/blob/8.x-3.x/webonyx/graphql-php` and gives a 404. This just points us to the right place.