### PR TITLE
Support cacheable request errors at execution

### DIFF
--- a/src/GraphQL/Cache/CacheableRequestError.php
+++ b/src/GraphQL/Cache/CacheableRequestError.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Cache;
+
+use GraphQL\Server\RequestError;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Cache\RefinableCacheableDependencyTrait;
+
+/**
+ * Cacheable Request Error.
+ */
+class CacheableRequestError extends RequestError implements CacheableDependencyInterface {
+  use RefinableCacheableDependencyTrait;
+}

--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -9,6 +9,7 @@ use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\graphql\Plugin\SchemaPluginManager;
 use Drupal\graphql\GraphQL\QueryProvider\QueryProviderInterface;
+use Drupal\graphql\GraphQL\Cache\CacheableRequestError;
 use GraphQL\Error\Error;
 use GraphQL\Error\FormattedError;
 use GraphQL\Executor\ExecutionResult;
@@ -274,6 +275,11 @@ class QueryProcessor {
       }
 
       return $this->executeUncachableOperation($adapter, $config, $params, $document);
+    }
+    catch (CacheableRequestError $exception) {
+      return $adapter->createFulfilled(
+        new QueryResult(NULL, [Error::createLocatedError($exception)], [], $exception)
+      );
     }
     catch (RequestError $exception) {
       return $adapter->createFulfilled(new QueryResult(NULL, [Error::createLocatedError($exception)]));


### PR DESCRIPTION
I need to cache error responses at the execution of the GraphQL operation level, for example a QueryProvider which is good for performance to cache using cache-tags.

Using the [GraphQL APQ module](https://github.com/lucasconstantino/drupal-graphql-apq) we notice that the errors like https://github.com/drupal-graphql/graphql/compare/8.x-3.x...TallerWebSolutions:cacheable-request-error?expand=1#diff-d1ec419a8a0948576da054d33fffbc74R285 were cached, which is ok, but there's no way to define a cache-tag or max-age when the QueryProvider fails since there's no query (with the hash) stored yet.

Here's in use: https://github.com/lucasconstantino/drupal-graphql-apq/pull/1

Suggestions on other ways to solve this, would be appreciated :)