### PR TITLE
Respect currently negotiated language.

### DIFF
--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -478,6 +478,8 @@ class QueryProcessor {
    *
    * Removes the language contexts from a list of context ids.
    *
+   * @deprecated
+   *
    * @param string[] $contexts
    *   The list of context id's.
    *
@@ -485,8 +487,6 @@ class QueryProcessor {
    *   The filtered list of context id's.
    */
   protected function filterCacheContexts(array $contexts) {
-    return array_filter($contexts, function ($context) {
-      return strpos($context, 'languages:') !== 0;
-    });
+    return $contexts;
   }
 }

--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -292,7 +292,7 @@ class QueryProcessor {
     return $promise->then(function (ExecutionResult $result) use ($context) {
 
       $metadata = (new CacheableMetadata())
-        ->addCacheContexts($this->filterCacheContexts($context->getCacheContexts()))
+        ->addCacheContexts($context->getCacheContexts())
         ->addCacheTags($context->getCacheTags())
         ->setCacheMaxAge($context->getCacheMaxAge());
 
@@ -457,7 +457,7 @@ class QueryProcessor {
    */
   protected function cacheIdentifier(OperationParams $params, DocumentNode $document, CacheableMetadata $metadata) {
     // Ignore language contexts since they are handled by graphql internally.
-    $contexts = $this->filterCacheContexts($metadata->getCacheContexts());
+    $contexts = $metadata->getCacheContexts();
     $keys = $this->contextsManager->convertTokensToKeys($contexts)->getKeys();
 
     // Sorting the variables will cause fewer cache vectors.
@@ -473,20 +473,4 @@ class QueryProcessor {
     return implode(':', array_values(array_merge([$hash], $keys)));
   }
 
-  /**
-   * Filter unused contexts.
-   *
-   * Removes the language contexts from a list of context ids.
-   *
-   * @deprecated
-   *
-   * @param string[] $contexts
-   *   The list of context id's.
-   *
-   * @return string[]
-   *   The filtered list of context id's.
-   */
-  protected function filterCacheContexts(array $contexts) {
-    return $contexts;
-  }
 }

--- a/src/GraphQL/Execution/ResolveContext.php
+++ b/src/GraphQL/Execution/ResolveContext.php
@@ -24,13 +24,23 @@ class ResolveContext implements RefinableCacheableDependencyInterface {
   protected $contexts = [];
 
   /**
+   * Root context values that will apply if no more specific context is there.
+   *
+   * @var array
+   */
+  protected $rootContext = [];
+
+  /**
    * ResolveContext constructor.
    *
    * @param array $globals
    *   List of global values to expose to field resolvers.
+   * @param array $rootContext
+   *   The root context values the query will be initialised with.
    */
-  public function __construct(array $globals = []) {
+  public function __construct(array $globals = [], $rootContext = []) {
     $this->globals = $globals;
+    $this->rootContext = $rootContext;
   }
 
   /**
@@ -60,6 +70,10 @@ class ResolveContext implements RefinableCacheableDependencyInterface {
       }
       array_pop($path);
     } while (count($path));
+
+    if (isset($this->rootContext[$name])) {
+      return $this->rootContext[$name];
+    }
 
     return $default;
   }

--- a/src/GraphQLLanguageContext.php
+++ b/src/GraphQLLanguageContext.php
@@ -24,6 +24,11 @@ class GraphQLLanguageContext {
   protected $currentLanguage;
 
   /**
+   * @var array
+   */
+  protected $languageStack = [];
+
+  /**
    * The language manager service.
    *
    * @var \Drupal\Core\Language\LanguageManagerInterface
@@ -67,6 +72,7 @@ class GraphQLLanguageContext {
    *   Any exception caught while executing the callable.
    */
   public function executeInLanguageContext(callable $callable, $language) {
+    $this->languageStack[] = $this->currentLanguage;
     $this->currentLanguage = $language;
     $this->isActive = TRUE;
     $this->languageManager->reset();
@@ -79,7 +85,7 @@ class GraphQLLanguageContext {
     }
     finally {
       // In any case, set the language context back to null.
-      $this->currentLanguage = NULL;
+      $this->currentLanguage = array_pop($this->languageStack);
       $this->isActive = FALSE;
       $this->languageManager->reset();
     }

--- a/src/GraphQLLanguageContext.php
+++ b/src/GraphQLLanguageContext.php
@@ -24,9 +24,9 @@ class GraphQLLanguageContext {
   protected $currentLanguage;
 
   /**
-   * @var array
+   * @var \SplStack
    */
-  protected $languageStack = [];
+  protected $languageStack;
 
   /**
    * The language manager service.
@@ -43,6 +43,7 @@ class GraphQLLanguageContext {
    */
   public function __construct(LanguageManagerInterface $languageManager) {
     $this->languageManager = $languageManager;
+    $this->languageStack = new \SplStack();
   }
 
   /**
@@ -72,7 +73,7 @@ class GraphQLLanguageContext {
    *   Any exception caught while executing the callable.
    */
   public function executeInLanguageContext(callable $callable, $language) {
-    $this->languageStack[] = $this->currentLanguage;
+    $this->languageStack->push($this->currentLanguage);
     $this->currentLanguage = $language;
     $this->isActive = TRUE;
     $this->languageManager->reset();
@@ -85,7 +86,7 @@ class GraphQLLanguageContext {
     }
     finally {
       // In any case, set the language context back to null.
-      $this->currentLanguage = array_pop($this->languageStack);
+      $this->currentLanguage = $this->languageStack->pop();
       $this->isActive = FALSE;
       $this->languageManager->reset();
     }

--- a/src/Plugin/GraphQL/Fields/FieldPluginBase.php
+++ b/src/Plugin/GraphQL/Fields/FieldPluginBase.php
@@ -118,9 +118,7 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
       if (array_key_exists($argument, $args) && !is_null($args[$argument])) {
         $context->setContext($argument, $args[$argument], $info);
       }
-      else {
-        $args[$argument] = $context->getContext($argument, $info);
-      }
+      $args[$argument] = $context->getContext($argument, $info, $context->getGlobal($argument));
     }
 
     if ($this->isLanguageAwareField()) {

--- a/src/Plugin/GraphQL/Fields/FieldPluginBase.php
+++ b/src/Plugin/GraphQL/Fields/FieldPluginBase.php
@@ -124,14 +124,14 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
       if (array_key_exists($argument, $args) && !is_null($args[$argument])) {
         $context->setContext($argument, $args[$argument], $info);
       }
-      $args[$argument] = $context->getContext($argument, $info, $context->getGlobal($argument));
+      $args[$argument] = $context->getContext($argument, $info);
     }
 
     if ($this->isLanguageAwareField()) {
       return $this->getLanguageContext()
         ->executeInLanguageContext(function () use ($value, $args, $context, $info) {
           return $this->resolveDeferred([$this, 'resolveValues'], $value, $args, $context, $info);
-        }, $context->getContext('language', $info, $context->getGlobal('language')));
+        }, $context->getContext('language', $info));
     }
     else {
       return $this->resolveDeferred([$this, 'resolveValues'], $value, $args, $context, $info);

--- a/src/Plugin/GraphQL/Fields/FieldPluginBase.php
+++ b/src/Plugin/GraphQL/Fields/FieldPluginBase.php
@@ -44,6 +44,13 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
   protected $renderer;
 
   /**
+   * Static cache for `isLanguageAwareField()`
+   *
+   * @var boolean
+   */
+  protected $isLanguageAware = NULL;
+
+  /**
    * {@inheritdoc}
    */
   public static function createInstance(SchemaBuilderInterface $builder, FieldPluginManager $manager, $definition, $id) {
@@ -140,9 +147,12 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
    *   The fields language awareness status.
    */
   protected function isLanguageAwareField() {
-    return (boolean) count(array_filter($this->getPluginDefinition()['response_cache_contexts'], function ($context) {
-      return strpos($context, 'languages:') === 0;
-    }));
+    if (is_null($this->isLanguageAware)) {
+      $this->isLanguageAware = (boolean) count(array_filter($this->getPluginDefinition()['response_cache_contexts'], function ($context) {
+        return strpos($context, 'languages:') === 0;
+      }));
+    }
+    return $this->isLanguageAware;
   }
 
   /**

--- a/src/Plugin/GraphQL/Fields/FieldPluginBase.php
+++ b/src/Plugin/GraphQL/Fields/FieldPluginBase.php
@@ -16,7 +16,6 @@ use Drupal\graphql\Plugin\GraphQL\Traits\CacheablePluginTrait;
 use Drupal\graphql\Plugin\GraphQL\Traits\DeprecatablePluginTrait;
 use Drupal\graphql\Plugin\GraphQL\Traits\DescribablePluginTrait;
 use Drupal\graphql\Plugin\GraphQL\Traits\TypedPluginTrait;
-use Drupal\graphql\Plugin\LanguageNegotiation\LanguageNegotiationGraphQL;
 use Drupal\graphql\Plugin\SchemaBuilderInterface;
 use GraphQL\Deferred;
 use GraphQL\Type\Definition\ListOfType;
@@ -125,7 +124,7 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
       return $this->getLanguageContext()
         ->executeInLanguageContext(function () use ($value, $args, $context, $info) {
           return $this->resolveDeferred([$this, 'resolveValues'], $value, $args, $context, $info);
-        }, $context->getContext('language', $info));
+        }, $context->getContext('language', $info, $context->getGlobal('language')));
     }
     else {
       return $this->resolveDeferred([$this, 'resolveValues'], $value, $args, $context, $info);

--- a/src/Plugin/GraphQL/Fields/FieldPluginBase.php
+++ b/src/Plugin/GraphQL/Fields/FieldPluginBase.php
@@ -164,9 +164,22 @@ abstract class FieldPluginBase extends PluginBase implements FieldPluginInterfac
     }
 
     if (is_callable($result)) {
-      return new Deferred(function () use ($result, $value, $args, $context, $info) {
-        return $this->resolveDeferred($result, $value, $args, $context, $info);
-      });
+      return new Deferred(
+        function () use ($result, $value, $args, $context, $info) {
+          if ($this->isLanguageAwareField()) {
+            return $this->getLanguageContext()
+              ->executeInLanguageContext(
+                function () use ($result, $value, $args, $context, $info) {
+                  return $this->resolveDeferred($result, $value, $args, $context, $info);
+                },
+                $context->getContext('language', $info)
+              );
+          }
+          else {
+            return $this->resolveDeferred($result, $value, $args, $context, $info);
+          }
+        }
+      );
     }
 
     // Only collect cache metadata if this is a query. All other operation types

--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
@@ -267,6 +267,7 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
         'languages:language_url',
         'languages:language_interface',
         'languages:language_content',
+        'user.permissions',
       ]);
       if ($this instanceof CacheableDependencyInterface) {
         $context->addCacheableDependency($this);

--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
@@ -246,9 +246,6 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
     // the secure fields restriction.
     $globals['bypass field security'] = $this->currentUser->hasPermission('bypass graphql field security');
 
-    // Populate globals with the current language.
-    $globals['language'] = $this->languageManager->getCurrentLanguage()->getId();
-
     // Create the server config.
     $config = ServerConfig::create();
 
@@ -259,7 +256,9 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
       // Each document (e.g. in a batch query) gets its own resolve context. This
       // allows us to collect the cache metadata and contextual values (e.g.
       // inheritance for language) for each query separately.
-      $context = new ResolveContext($globals);
+      $context = new ResolveContext($globals, [
+        'language' => $this->languageManager->getCurrentLanguage()->getId(),
+      ]);
       $context->addCacheTags(['graphql_response']);
 
       // Always add the language_url cache context.

--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
@@ -541,9 +541,7 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
    * {@inheritdoc}
    */
   public function getCacheContexts() {
-    return [
-
-    ];
+    return [];
   }
 
   /**

--- a/tests/src/Kernel/Framework/LanguageContextTest.php
+++ b/tests/src/Kernel/Framework/LanguageContextTest.php
@@ -45,6 +45,17 @@ class LanguageContextTest extends GraphQLTestBase {
       yield \Drupal::languageManager()->getCurrentLanguage()->getId();
     });
 
+    $this->mockField('deferred', [
+      'name' => 'deferred',
+      'parents' => ['Root', 'Node'],
+      'type' => 'String',
+      'response_cache_contexts' => ['languages:language_interface'],
+    ], function () {
+      return function () {
+        yield \Drupal::languageManager()->getCurrentLanguage()->getId();
+      };
+    });
+
     $this->mockField('unaware', [
       'name' => 'unaware',
       'parents' => ['Root', 'Node'],
@@ -156,6 +167,31 @@ GQL;
     $this->assertResults($query, [], [
       'edge' => [
         'language' => 'fr',
+      ],
+    ], $this->defaultCacheMetaData());
+  }
+
+  /**
+   * Test deferred language resolvers.
+   */
+  public function testDeferredLanguage() {
+    $query = <<<GQL
+query {
+  edge(language: "fr") {
+    deferred
+    edge(language: "en") {
+      deferred
+    }
+  }
+}
+GQL;
+
+    $this->assertResults($query, [], [
+      'edge' => [
+        'deferred' => 'fr',
+        'edge' => [
+          'deferred' => 'en',
+        ],
       ],
     ], $this->defaultCacheMetaData());
   }

--- a/tests/src/Kernel/Framework/SecureFieldTest.php
+++ b/tests/src/Kernel/Framework/SecureFieldTest.php
@@ -57,7 +57,6 @@ class SecureFieldTest extends GraphQLTestBase {
    */
   public function testInsecureField() {
     $metadata = $this->defaultCacheMetaData();
-    $metadata->setCacheContexts([]);
     $metadata->setCacheMaxAge(0);
     $this->assertErrors('{ insecure }', [], [
       'Unable to resolve insecure field \'insecure\'.',

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -81,7 +81,12 @@ abstract class GraphQLTestBase extends KernelTestBase {
    * {@inheritdoc}
    */
   protected function defaultCacheContexts() {
-    return ['user.permissions'];
+    return [
+      'user.permissions',
+      'languages:language_url',
+      'languages:language_interface',
+      'languages:language_content',
+    ];
   }
 
   /**

--- a/tests/src/Traits/MockGraphQLPluginTrait.php
+++ b/tests/src/Traits/MockGraphQLPluginTrait.php
@@ -298,6 +298,7 @@ trait MockGraphQLPluginTrait {
       $this->container->get('graphql.query_provider'),
       $this->container->get('current_user'),
       $this->container->get('logger.channel.graphql'),
+      $this->container->get('language_manager'),
       $this->container->getParameter('graphql.config')
     ]);
 

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -77,6 +77,7 @@ trait QueryResultAssertionTrait {
    */
   protected function defaultMutationCacheMetaData() {
     $metadata = new CacheableMetadata();
+    $metadata->setCacheContexts($this->defaultCacheContexts());
     $metadata->setCacheMaxAge(0);
     $metadata->setCacheTags($this->defaultCacheTags());
     return $metadata;


### PR DESCRIPTION
Set global query variable to current language and use it for
contextual arguments. Add languages to cache contexts.