### PR TITLE
Check for link attributes that are arrays and implode them.

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Entity/Fields/Link/LinkAttribute.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Entity/Fields/Link/LinkAttribute.php
@@ -31,7 +31,14 @@ class LinkAttribute extends FieldPluginBase {
   protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
     if ($value instanceof LinkItemInterface) {
       $options = $value->getUrl()->getOptions();
-      yield NestedArray::getValue($options, ['attributes', $args['key']]);
+
+      // Certain attributes like class can be arrays. Check for that and implode them.
+      $attributeValue = NestedArray::getValue($options, ['attributes', $args['key']]);
+      if (is_array($attributeValue)) {
+        yield implode(" ", $attributeValue);
+      } else {
+        yield $attributeValue;
+      }
     }
   }
 

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Entity/Fields/Link/LinkAttribute.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Entity/Fields/Link/LinkAttribute.php
@@ -35,7 +35,7 @@ class LinkAttribute extends FieldPluginBase {
       // Certain attributes like class can be arrays. Check for that and implode them.
       $attributeValue = NestedArray::getValue($options, ['attributes', $args['key']]);
       if (is_array($attributeValue)) {
-        yield implode(" ", $attributeValue);
+        yield implode(' ', $attributeValue);
       } else {
         yield $attributeValue;
       }

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkAttribute.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkAttribute.php
@@ -30,7 +30,14 @@ class MenuLinkAttribute extends FieldPluginBase {
   protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
     if ($value instanceof MenuLinkTreeElement) {
       $options = $value->link->getOptions();
-      yield NestedArray::getValue($options, ['attributes', $args['key']]);
+
+      // Certain attributes like class can be arrays. Check for that and implode them.
+      $attributeValue = NestedArray::getValue($options, ['attributes', $args['key']]);
+      if (is_array($attributeValue)) {
+        yield implode(" ", $attributeValue);
+      } else {
+        yield $attributeValue;
+      }
     }
   }
 

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkAttribute.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkAttribute.php
@@ -34,7 +34,7 @@ class MenuLinkAttribute extends FieldPluginBase {
       // Certain attributes like class can be arrays. Check for that and implode them.
       $attributeValue = NestedArray::getValue($options, ['attributes', $args['key']]);
       if (is_array($attributeValue)) {
-        yield implode(" ", $attributeValue);
+        yield implode(' ', $attributeValue);
       } else {
         yield $attributeValue;
       }


### PR DESCRIPTION
The Link Attributes module recently implemented a change where it stores classes as an array instead of a string: https://www.drupal.org/project/link_attributes/issues/2900624

This breaks the MenuLinkAttribute and LinkAttribute fields which yield a string. Check if the attribute we are trying to yield is an array and implode it with a space if it is.