### PR TITLE
Fixing incorrect parent names in EntityFieldValueTest asserts

### DIFF
--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityFieldValueTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityFieldValueTest.php
@@ -86,9 +86,9 @@ GQL;
 
     $this->assertGraphQLFields([
       ['NodeTest', 'fieldText', 'FieldNodeTestFieldText'],
-      ['FieldNodeFieldText', 'value', 'String'],
-      ['FieldNodeFieldText', 'processed', 'String'],
-      ['FieldNodeFieldText', 'format', 'String'],
+      ['FieldNodeTestFieldText', 'value', 'String'],
+      ['FieldNodeTestFieldText', 'processed', 'String'],
+      ['FieldNodeTestFieldText', 'format', 'String'],
     ]);
 
     $query = <<<GQL
@@ -130,11 +130,11 @@ GQL;
 
     $this->assertGraphQLFields([
       ['NodeTest', 'body', 'FieldNodeTestBody'],
-      ['FieldNodeBody', 'format', 'String'],
-      ['FieldNodeBody', 'value', 'String'],
-      ['FieldNodeBody', 'processed', 'String'],
-      ['FieldNodeBody', 'summary', 'String'],
-      ['FieldNodeBody', 'summaryProcessed', 'String'],
+      ['FieldNodeTestBody', 'format', 'String'],
+      ['FieldNodeTestBody', 'value', 'String'],
+      ['FieldNodeTestBody', 'processed', 'String'],
+      ['FieldNodeTestBody', 'summary', 'String'],
+      ['FieldNodeTestBody', 'summaryProcessed', 'String'],
     ]);
 
     $query = <<<GQL


### PR DESCRIPTION
This fixes two of the three tests that are failing on #684 