### PR TITLE
Fix broken entity reference query filter.

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityReference/EntityReferenceQuery.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityReference/EntityReferenceQuery.php
@@ -52,7 +52,8 @@ class EntityReferenceQuery extends EntityQuery {
         return NULL;
       }
 
-      $query->condition($key, $ids);
+      $operator = is_array($ids) ? 'IN' : '=';
+      $query->condition($key, $ids, $operator);
 
       return $query;
     }


### PR DESCRIPTION
Today with @pavlosdan we worked on referenced entities.
Also see #660 
Doing a query like this:
```
query getStoryFragments(
  $id: String = "4815",
    $status: [String] = "1",
) {
    stories: nodeQuery(
        filter: {
            conditions:
            [
                {
                  field: "nid",
                  value: [$id]
                },
                {
                  field: "status",
                  value: $status
                },
                  {
                  field: "type",
                  value: "story"
                }
            ]
        }
    ) {
        story: entities {
            ... on NodeStory {
              status
              title
              queryFieldStoryFragments(
                filter: {
                  conditions:
                  [
                    {
                      field: "status",
                      value: $status
                    }
                  ]
              }) {
                entities {
                  entityLabel
                }
              }
            }
        }
    }
}
```
Whould result in:
```
"errors": [
    {
      "debugMessage": "SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens: SELECT base_table.vid AS vid, base_table.nid AS nid\nFROM\n{node} base_table\nINNER JOIN {node_field_data} node_field_data ON node_field_data.nid = base_table.nid\nINNER JOIN {node_field_data} node_field_data_2 ON node_field_data_2.nid = base_table.nid\nWHERE (node_field_data.nid = :db_condition_placeholder_0:db_condition_placeholder_1) AND (node_field_data_2.status = :db_condition_placeholder_2)\nGROUP BY base_table.vid, base_table.nid\nLIMIT 10 OFFSET 0; Array\n(\n    [:db_condition_placeholder_0] => 4813\n    [:db_condition_placeholder_1] => 4814\n    [:db_condition_placeholder_2] => 1\n)\n",
```
Pavlos fixed it by checking if the ids is an array and if so change the query into 'IN' instead of '='