### PR TITLE
Prevent cache collisions for GraphQL subrequests

### DIFF
--- a/src/GraphQL/Buffers/SubRequestBuffer.php
+++ b/src/GraphQL/Buffers/SubRequestBuffer.php
@@ -89,6 +89,7 @@ class SubRequestBuffer extends BufferBase {
       $currentRequest->files->all(),
       $currentRequest->server->all()
     );
+    $request->setRequestFormat('_graphql_subrequest');
 
     $request->attributes->set('_graphql_subrequest', function () use ($buffer) {
       return array_map(function ($item) {


### PR DESCRIPTION
This pull request represents our (= the development team I work with) solution for a problem we had with GraphQL subrequests and the fact that Drupal uses many different caches which collide because their keys aren't unique enough. I'm offering it here for feedback; it might not be the best solution, but it's what we came up with after spending many hours stepping through Drupal in a PHP debugger. If it's a good solution, then by all means, please merge this PR. If there's something better, I'd be interested in trying it.

Let me describe the problem first. I'll try to not make this too long a story. ;)

Our application is a website consisting of a headless Drupal installation with a separate frontend, which is built in React. To get the data from Drupal onto the website, we use GraphQL. Specifically, every page visited on the frontend leads to a query we've called `ContentDetails` with a path variable that contains the entire path of the page. The result contains many paragraph types, fields, entities; basically anything we need to build up the page in the frontend.

Every so often, a page would fail on us; the GraphQL response would contain an 'error' key with a message and line/column number indicator which, after investigation, turns out to indicate the fields in the query on which the problem occurred (initially, we assumed it to refer to some PHP source file). Every time this happened, the field that errored was one that contained a reference to something in Drupal that has a URL. The error field in the JSON lead to a rendering error in our frontend application, causing error pages for the end user.

During our investigation, the error situation turned out to correspond with an error in our logs:

    Call to undefined method Drupal\Core\Render\HtmlResponse::getResult()

Unfortunately, no trace was logged for this error, but eventually, we found out that this error occurred in `src/GraphQL/Buffers/SubRequestBuffer.php` of the drupal/graphql dependency, specifically in the last (return) statement of `resolveBufferArray()`:

    return array_map(function ($value) use ($response) {
      return new CacheableValue($value, [$response]);
    }, $response->getResult());

This `$response` is being type-hinted, through a PHPDoc comment, to be an instance of `\Drupal\graphql\GraphQL\Buffers\SubRequestResponse`, but the problem clearly is that this isn't a guarantee; sometimes it's an `HtmlResponse` and the error occurs because there is no `getResult()` in those objects. This error situation isn't really resolved or caught, so it leads to an error-entry in the eventual JSON result from the GraphQL call.

Now, aside from the fact that the code doesn't do any type checking, the error is that the `HtmlResponse` is returned in the first place. And that's what we went to investigate, not knowing anything about the internal workings of either Drupal or the GraphQL implementation.

It turned out to be quite hard to find out where the `HtmlResponse` came from; putting breakpoints in the class itself didn't clear anything up and stepping through the code from `resolveBufferArray()` onwards lead to a lot of dead ends (or `SubRequestResponse`s). But eventually, we realised that the request that was created in that method seemed to be a regular HTTP request for a path that, as it turns out, was the same path we were supplying as the `$path` parameter in our `ContentDetails` query. It wasn't (and still isn't) clear why this request is performed, nor was it clear why it could return an HTML page when the code was expecting something else.

Long story short: the `HtmlResponse` came directly from the cache.  An entry with the following cache key (the hash of which varies, of course) turned out to contain exactly the `HtmlResponse` that was returned in the `SubRequestBuffer` class:

    response:[request_format]=html:[route]=entity.node.canonical1f644f584eb1d4a4c70ad5b70ac75a7e6a8bd4e78f8a08875adb50c6690b59df

Whenever we deleted this entry, everything was right again. We found out that the cache entry was being generated whenever a visitor requested the page corresponding to the path in the query (to be clear: the page would be requested on the backend - that this could happen at all was a problem in itself but technically quite separate from the problem at hand). And yes, that would lead to (roughly) the same `$request` as in the `SubRequestBuffer`, so the match isn't that far fetched. Whenever the cache with the `HtmlResponse` was present, that was the one that was returned, instead of something that was actually expected.

Above, I said roughly the same request: it obviously isn't exactly the same request, because this SubRequest for GraphQL isn't supposed to return an HTML page (or so we assumed). The difference in the request is visible in `SubRequestBuffer`: an extra attribute is set on the request. We suspected that this is wat made the request something that should be routed to a GraphQL related controller instead of something that generates an HTML page. But the cache key of this request does not incorporate this difference, which is why, in the context of caching, the two requests are very easily mixed up, and why the cache of one request could be returned as a response to the other one.

So, after this long journey into "where the hell does this response come from?", we figured we should make sure the cache key of the GraphQL subrequest is no longer likely to collide with the one for the HTML page. If you look back at the cache key above, you can see that there is a `request_format` which says `html`. The easiest and most solution secure we could find, which is also one that felt somewhat semantically right, is to give the request a different format label. We chose the label `_graphql_subrequest` after the name of the attribute, and added the line to the `SubRequestBuffer` class:

    $request->setRequestFormat('_graphql_subrequest');

With this one line, the cache key became unique (because the cache key now contained this unique label), never collided with the HTML page again and our randomly occurring errors seized to exist.

I totally feel that we have merely patched the code to fix the problem in a way that directly addresses what we could clearly see to be wrong; maybe, with more knowledge of how everything was designed to work, we might have come up with something different altogether. And that's why I wrote up this whole story, to give context to the situation.

We are now running our production website with a patched version of `SubRequestBuffer.php`. If either our solution could be included in the next release or replaced with an architecturally more sound one, we would love to update to that version, so we don't have to rely on install-time patches anymore.

Of course, if anything in my story is unclear, please ask and I'll clarify.
