### PR TITLE
Fixed so return type is not required for entity reference queries.

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityReference/EntityReferenceQuery.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityReference/EntityReferenceQuery.php
@@ -11,7 +11,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  * @GraphQLField(
  *   id = "entity_reference_query",
  *   secure = true,
- *   type = "EntityQueryResult!",
+ *   type = "EntityQueryResult",
  *   arguments = {
  *     "filter" = "EntityQueryFilterInput",
  *     "sort" = "[EntityQuerySortInput]",


### PR DESCRIPTION
Since the EntityQuery which this extends doesn't require a EntityQueryResult I thought I'd remove it here as well. It resolved the issue for me.