### PR TITLE
Prevent serialization of already serialized Map Scalar data

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Scalars/TypedData/Map.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Scalars/TypedData/Map.php
@@ -17,14 +17,7 @@ class Map extends ScalarPluginBase {
    * {@inheritdoc}
    */
   public static function serialize($value) {
-    if (is_array($value)) {
-      return json_encode($value);
-    }
-    if (is_string($value) && json_decode($value)) {
-      return $value;
-    }
-
-    return NULL;
+    return $value;
   }
 
   /**

--- a/modules/graphql_core/src/Plugin/GraphQL/Scalars/TypedData/Map.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Scalars/TypedData/Map.php
@@ -20,6 +20,9 @@ class Map extends ScalarPluginBase {
     if (is_array($value)) {
       return json_encode($value);
     }
+    if (is_string($value) && json_decode($value)) {
+      return $value;
+    }
 
     return NULL;
   }


### PR DESCRIPTION
Fixes issue with Map type fields like f.e. table fields https://www.drupal.org/project/tablefield 
It was always returning null for the value:
```
"table": {
  "value": null,
  "format": null
}
```
This change is needed as `Map::serialize()` is called twice when retrieving the data.