### PR TITLE
fix(EntityLoad): Allow passing NULL as id

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -25,7 +25,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *       label = @Translation("Entity type")
  *     ),
  *     "entity_id" = @ContextDefinition("string",
- *       label = @Translation("Identifier")
+ *       label = @Translation("Identifier"),
+ *       required = FALSE
  *     ),
  *     "entity_language" = @ContextDefinition("string",
  *       label = @Translation("Entity languages(s)"),
@@ -120,7 +121,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $id, $language = NULL, $bundles = NULL, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve($type, $id = NULL, $language = NULL, $bundles = NULL, RefinableCacheableDependencyInterface $metadata) {
     $resolver = $this->entityBuffer->add($type, $id);
 
     return new Deferred(function () use ($type, $id, $language, $bundles, $resolver, $metadata) {


### PR DESCRIPTION
When chaining producers is possible that an entity_load receives NULL.

I am not sure this is the proper fix to be honest..feels a little weird for it to make the entity_id optionl :/

Can replicate this with for example : 

``` 
$registry->addFieldResolver('JobPage', 'salaryRange',
      $builder->produce('entity_load', [
        'mapping' => [
          'entity_type' => $builder->fromValue('taxonomy_term'),
          'entity_bundle' => $builder->fromValue(['salary_range']),
          'entity_id' => NULL,
        ],
      ])
    );
```

It throws the error : 

""Missing input data mapper for entity_id on field salaryRange on type JobPage"