### PR TITLE
feat(Entity): Include Entity load multiple producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -135,10 +135,13 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
       }
 
       foreach ($entities as $id => $entity) {
+
+        $metadata->addCacheableDependency($entities[$id]);
+
         if (isset($bundles) && !in_array($entities[$id]->bundle(), $bundles)) {
           // If the entity is not among the allowed bundles, don't return it.
-          $metadata->addCacheableDependency($entities[$id]);
           unset($entities[$id]);
+          continue;
         }
 
         if (isset($language) && $language != $entities[$id]->language()
@@ -147,11 +150,12 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
         }
 
         $access = $entity->access('view', NULL, TRUE);
+        $metadata->addCacheableDependency($access);
+
         if (!$access->isAllowed()) {
           // Do not return the entity if access is denied.
-          $metadata->addCacheableDependency($entities[$id]);
-          $metadata->addCacheableDependency($access);
           unset($entities[$id]);
+          continue;
         }
 
       }

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -112,15 +112,15 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
   }
 
   /**
-   * @param $type
-   * @param $ids
-   * @param null $language
-   * @param null $bundles
+   * @param string $type
+   * @param int[] $ids
+   * @param string $language
+   * @param string[] $bundles
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $ids, $language = NULL, $bundles = NULL, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve(string $type, array $ids, string $language = NULL, array $bundles = NULL, RefinableCacheableDependencyInterface $metadata) {
     $resolver = $this->entityBuffer->add($type, $ids);
 
     return new Deferred(function () use ($type, $ids, $language, $bundles, $resolver, $metadata) {
@@ -149,6 +149,8 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
         $access = $entity->access('view', NULL, TRUE);
         if (!$access->isAllowed()) {
           // Do not return the entity if access is denied.
+          $metadata->addCacheableDependency($entities[$id]);
+          $metadata->addCacheableDependency($access);
           unset($entities[$id]);
         }
 

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use GraphQL\Deferred;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @DataProducer(
+ *   id = "entity_load_multiple",
+ *   name = @Translation("Load multiple entities"),
+ *   description = @Translation("Loads multiple entities."),
+ *   produces = @ContextDefinition("entities",
+ *     label = @Translation("Entities")
+ *   ),
+ *   consumes = {
+ *     "entity_type" = @ContextDefinition("string",
+ *       label = @Translation("Entity type")
+ *     ),
+ *     "entity_ids" = @ContextDefinition("array",
+ *       label = @Translation("Identifier")
+ *     ),
+ *     "entity_language" = @ContextDefinition("string",
+ *       label = @Translation("Entity languages(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "entity_bundle" = @ContextDefinition("string",
+ *       label = @Translation("Entity bundle(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The entity buffer service.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
+   */
+  protected $entityBuffer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity.repository'),
+      $container->get('graphql.buffer.entity')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
+   *   The entity repository service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $entityBuffer
+   *   The entity buffer service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    $configuration,
+    $pluginId,
+    $pluginDefinition,
+    EntityTypeManager $entityTypeManager,
+    EntityRepositoryInterface $entityRepository,
+    EntityBuffer $entityBuffer
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityRepository = $entityRepository;
+    $this->entityBuffer = $entityBuffer;
+  }
+
+  /**
+   * @param $type
+   * @param $ids
+   * @param null $language
+   * @param null $bundles
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *
+   * @return \GraphQL\Deferred
+   */
+  public function resolve($type, $ids, $language = NULL, $bundles = NULL, RefinableCacheableDependencyInterface $metadata) {
+    $resolver = $this->entityBuffer->add($type, $ids);
+
+    return new Deferred(function () use ($type, $ids, $language, $bundles, $resolver, $metadata) {
+      if (!$entities = $resolver()) {
+        // If there is no entity with this id, add the list cache tags so that the
+        // cache entry is purged whenever a new entity of this type is saved.
+        $type = $this->entityTypeManager->getDefinition($type);
+        /** @var \Drupal\Core\Entity\EntityTypeInterface $type */
+        $tags = $type->getListCacheTags();
+        $metadata->addCacheTags($tags);
+        return NULL;
+      }
+
+      foreach ($entities as $id => $entity) {
+        if (isset($bundles) && !in_array($entities[$id]->bundle(), $bundles)) {
+          // If the entity is not among the allowed bundles, don't return it.
+          $metadata->addCacheableDependency($entities[$id]);
+          return NULL;
+        }
+
+        if (isset($language) && $language != $entities[$id]->language()
+            ->getId() && $entities[$id] instanceof TranslatableInterface) {
+          $entities[$id] = $entities[$id]->getTranslation($language);
+        }
+      }
+
+      return $entities;
+    });
+  }
+}

--- a/tests/src/Kernel/DataProducer/EntityMultipleTest.php
+++ b/tests/src/Kernel/DataProducer/EntityMultipleTest.php
@@ -70,15 +70,6 @@ class EntityMultipleTest extends GraphQLTestBase {
       'type' => 'lorem',
     ]);
     $this->node2->save();
-
-    $this->translation_fr = $this->node1->addTranslation('fr', ['title' => 'sit amet fr']);
-    $this->translation_fr->save();
-
-    $this->translation_de = $this->node1->addTranslation('de', ['title' => 'sit amet de']);
-    $this->translation_de->save();
-
-    \Drupal::service('content_translation.manager')
-      ->setEnabled('node', 'lorem', TRUE);
   }
 
   /**

--- a/tests/src/Kernel/DataProducer/EntityMultipleTest.php
+++ b/tests/src/Kernel/DataProducer/EntityMultipleTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel\DataProducer;
+
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\UserInterface;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
+use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
+use Drupal\Tests\graphql\Traits\QueryResultAssertionTrait;
+use Drupal\entity_test\Entity\EntityTestBundle;
+
+/**
+ * Data producers Entity multiple test class.
+ *
+ * @group graphql
+ */
+class EntityMultipleTest extends GraphQLTestBase {
+
+  use QueryResultAssertionTrait;
+
+  /**
+   * @var NodeInterface
+   */
+  protected $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->dataProducerManager = $this->container->get('plugin.manager.graphql.data_producer');
+    $this->entity = $this->getMockBuilder(NodeInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->entity_interface = $this->getMockBuilder(EntityInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->user = $this->getMockBuilder(UserInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $content_type = NodeType::create([
+      'type' => 'lorem',
+      'name' => 'ipsum',
+      'translatable' => TRUE,
+      'display_submitted' => FALSE,
+    ]);
+    $content_type->save();
+
+    $content_type = NodeType::create([
+      'type' => 'otherbundle',
+      'name' => 'otherbundle',
+      'translatable' => TRUE,
+      'display_submitted' => FALSE,
+    ]);
+    $content_type->save();
+
+    $this->node1 = Node::create([
+      'title' => 'Dolor',
+      'type' => 'lorem',
+    ]);
+    $this->node1->save();
+
+    $this->node2 = Node::create([
+      'title' => 'Dolor',
+      'type' => 'lorem',
+    ]);
+    $this->node2->save();
+
+    $this->translation_fr = $this->node1->addTranslation('fr', ['title' => 'sit amet fr']);
+    $this->translation_fr->save();
+
+    $this->translation_de = $this->node1->addTranslation('de', ['title' => 'sit amet de']);
+    $this->translation_de->save();
+
+    \Drupal::service('content_translation.manager')
+      ->setEnabled('node', 'lorem', TRUE);
+  }
+
+  /**
+   * @covers Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\EntityLoadMultiple::resolve
+   */
+  public function testResolveEntityLoadMultiple() {
+    $metadata = $this->defaultCacheMetaData();
+
+    $plugin = $this->dataProducerManager->getInstance([
+      'id' => 'entity_load_multiple',
+      'configuration' => [],
+    ]);
+
+    $deferred = $plugin->resolve($this->node->getEntityTypeId(), [
+      $this->node1->id(),
+      $this->node2->id(),
+    ], NULL, NULL, $metadata);
+
+    $adapter = new SyncPromiseAdapter();
+    $promise = $adapter->convertThenable($deferred);
+
+    $result = $adapter->wait($promise);
+
+    $nids = [];
+    foreach ($result as $item) {
+      $nids[] = $item->id();
+    }
+
+    // All entity is loaded through entity load should match the initial values.
+    $this->assertEquals($this->node->id(), $nids);
+  }
+
+}

--- a/tests/src/Kernel/DataProducer/EntityMultipleTest.php
+++ b/tests/src/Kernel/DataProducer/EntityMultipleTest.php
@@ -31,6 +31,11 @@ class EntityMultipleTest extends GraphQLTestBase {
   protected $node2;
 
   /**
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $node3;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
@@ -67,6 +72,13 @@ class EntityMultipleTest extends GraphQLTestBase {
       'status' => NodeInterface::PUBLISHED,
     ]);
     $this->node2->save();
+
+    $this->node3 = Node::create([
+      'title' => 'Dolor',
+      'type' => 'lorem',
+      'status' => NodeInterface::NOT_PUBLISHED,
+    ]);
+    $this->node3->save();
   }
 
   /**
@@ -92,6 +104,7 @@ class EntityMultipleTest extends GraphQLTestBase {
     $deferred = $plugin->resolve($this->node1->getEntityTypeId(), [
       $this->node1->id(),
       $this->node2->id(),
+      $this->node3->id(),
     ], NULL, [$this->node1->bundle(), $this->node2->bundle()], $metadata);
 
     $adapter = new SyncPromiseAdapter();
@@ -104,12 +117,13 @@ class EntityMultipleTest extends GraphQLTestBase {
       $nids[] = $item->id();
     }
 
-    $expected = [];
-    $expected[] = $this->node1->id();
-    $expected[] = $this->node2->id();
-
     // All entity is loaded through entity load should match the initial values.
-    $this->assertEquals($expected, $nids);
+    // Hidden entity (node 3) is not include
+    // because access checking will not return it.
+    $this->assertEquals([
+      $this->node1->id(),
+      $this->node2->id(),
+    ], $nids);
   }
 
 }

--- a/tests/src/Kernel/DataProducer/EntityMultipleTest.php
+++ b/tests/src/Kernel/DataProducer/EntityMultipleTest.php
@@ -83,7 +83,7 @@ class EntityMultipleTest extends GraphQLTestBase {
       'configuration' => [],
     ]);
 
-    $deferred = $plugin->resolve($this->node->getEntityTypeId(), [
+    $deferred = $plugin->resolve($this->node1->getEntityTypeId(), [
       $this->node1->id(),
       $this->node2->id(),
     ], NULL, NULL, $metadata);


### PR DESCRIPTION
A first attempt at creating an entity load multiple producer. 
It uses the same buffer as the entity load as it already supports arrays of ids passed to it.

Basically you could call it like : 

```php 
$builder->produce('entity_load_multiple', [
    'mapping' => [
    'entity_type' => $builder->fromValue('node'),
    'entity_ids' => $builder->fromValue([1,2,3])
  ],
]),
```

Feedback for improvements would be much appreciated as just getting my feet wet here ;P 