### PR TITLE
fix(data producer): Check for DataProducerInterface instead of class

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/ArgumentsResolver.php
+++ b/src/Plugin/GraphQL/DataProducer/ArgumentsResolver.php
@@ -44,7 +44,7 @@ class ArgumentsResolver {
       }
       $mapper = $this->getInputMapper($key);
 
-      if (isset($mapper) && !$mapper instanceof DataProducerCallable) {
+      if (isset($mapper) && !$mapper instanceof DataProducerInterface) {
         throw new \Exception(sprintf('Invalid input mapper for argument %s.', $key));
       }
 


### PR DESCRIPTION
Commit 49521846e18ee753d38508cf33d2d08637a051bb introduced this bug. We need to check the interface instead of the class.

We are also lacking test coverage here. What would be the best way to test this?