### PR TITLE
feat(context): Reintroduce context parameters for data producer plugins

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/ArgumentsResolver.php
+++ b/src/Plugin/GraphQL/DataProducer/ArgumentsResolver.php
@@ -35,8 +35,8 @@ class ArgumentsResolver {
     foreach ($params as $param) {
       $key = $param->getName();
 
-      // Do not process metadata argument.
-      if ($key == 'metadata') {
+      // Do not process special metadata, context and resolve info arguments.
+      if ($key == 'metadata' || $key == 'context' || $key == 'info') {
         continue;
       }
       if (!$param->isDefaultValueAvailable() && !$this->hasInputMapper($key)) {

--- a/src/Plugin/GraphQL/DataProducer/FieldExecutor.php
+++ b/src/Plugin/GraphQL/DataProducer/FieldExecutor.php
@@ -104,7 +104,7 @@ class FieldExecutor {
   protected function resolveUncached($values, ResolveContext $context, ResolveInfo $info, RefinableCacheableDependencyInterface $metadata) {
     $plugin = $this->getPlugin();
 
-    $output = call_user_func_array([$plugin, 'resolve'], array_merge($values, [$metadata]));
+    $output = call_user_func_array([$plugin, 'resolve'], array_merge($values, [$metadata, $context, $info]));
     return DeferredUtility::applyFinally($output, function ($value) use ($metadata) {
       if ($value instanceof CacheableDependencyInterface) {
         $metadata->addCacheableDependency($value);


### PR DESCRIPTION
We need some kind of context system in 4.x, while that is being developed we pass down the context with this.

So this should probably not be merged. The new context system will then be developed in #760 I assume.