### PR TITLE
Always validate query if is present in original input.

### DIFF
--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
@@ -276,7 +276,7 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
     });
 
     $config->setValidationRules(function (OperationParams $params, DocumentNode $document, $operation) {
-      if (isset($params->queryId)) {
+      if (isset($params->queryId) && empty($params->getOriginalInput('query')) {
         // Assume that pre-parsed documents are already validated. This allows
         // us to store pre-validated query documents e.g. for persisted queries
         // effectively improving performance by skipping run-time validation.


### PR DESCRIPTION
In module drupal-graphql-apq are queries always taken as valid because of this line.
Query (if present), should be always validated.