### PR TITLE
Fix typo in mutation docs

### DIFF
--- a/doc/mutations/README.md
+++ b/doc/mutations/README.md
@@ -4,7 +4,7 @@ In GraphQL, a mutation is the terminology used whenever you want to add, modify,
 
 Unfortunately, the module does not include a way to peform common mutations out of the box due to some technical requirements of graphql. You can read more about this at the amazeelabs blog post below.
 
-Mutations must be created in a custom module. In many cases you will extend existing provided classes for adding, updating, or deleting an entity. Specifically CreatEntityBase, DeleteEntityBase, or UpdateEntityBase.
+Mutations must be created in a custom module. In many cases you will extend existing provided classes for adding, updating, or deleting an entity. Specifically CreateEntityBase, DeleteEntityBase, or UpdateEntityBase.
 
 A fantastic resource for implementing mutations can be found at [https://www.amazeelabs.com/en/blog/extending-graphql-part-3-mutations](https://www.amazeelabs.com/en/blog/extending-graphql-part-3-mutations)
 


### PR DESCRIPTION
BTW: The linked blog-post is offline. Any chance to bring this back oder add it to the docs folder?

Thanks! 