### PR TITLE
Issue 785: Handling such content entities that do not support view modes

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRenderedDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityRenderedDeriver.php
@@ -4,6 +4,7 @@ namespace Drupal\graphql_core\Plugin\Deriver\Fields;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -21,10 +22,20 @@ class EntityRenderedDeriver extends DeriverBase implements ContainerDeriverInter
   protected $entityTypeManager;
 
   /**
+   * The entity display repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $basePluginId) {
-    return new static($container->get('entity_type.manager'));
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity_display.repository')
+    );
   }
 
   /**
@@ -32,9 +43,12 @@ class EntityRenderedDeriver extends DeriverBase implements ContainerDeriverInter
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entityDisplayRepository
+   *   The entity display repository service.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, EntityDisplayRepositoryInterface $entityDisplayRepository) {
     $this->entityTypeManager = $entityTypeManager;
+    $this->entityDisplayRepository = $entityDisplayRepository;
   }
 
   /**
@@ -42,7 +56,7 @@ class EntityRenderedDeriver extends DeriverBase implements ContainerDeriverInter
    */
   public function getDerivativeDefinitions($basePluginDefinition) {
     foreach ($this->entityTypeManager->getDefinitions() as $id => $type) {
-      if ($type instanceof ContentEntityTypeInterface) {
+      if ($type instanceof ContentEntityTypeInterface && !empty($this->entityDisplayRepository->getViewModes($id))) {
         $derivative = [
           'parents' => [StringHelper::camelCase($id)],
           'description' => $this->t("Renders '@type' entities in the given view mode.", ['@type' => $type->getLabel()]),


### PR DESCRIPTION
Hello, guys!

We are about to use GraphQL and I came across the same problem as documented in https://github.com/drupal-graphql/graphql/issues/785

In our case it was Redirect entity. Basically it is true, some content entities do not support view modes so GraphQL should do a bit stricter condition in its entity renderer deriver.

I had a look at how a content entities becomes compatible with view modes to come up with the reliable condition in the deriver. EntityViewMode config entity is defined in ./core/lib/Drupal/Core/Entity/Entity/EntityViewMode.php

There is also a dedicated service, apparently, to retrieve view modes: `EntityDisplayRepository`.

So I figured a non empty list of view modes is a pretty reliable indicator of whether the entity type in question supports them. This is the exact route I am taking in this patch.