### PR TITLE
Fix small typo in graphql.permissions.yml

### DIFF
--- a/graphql.permissions.yml
+++ b/graphql.permissions.yml
@@ -1,6 +1,6 @@
 'execute graphql requests':
   title: 'Execute arbitrary GraphQL requests'
-  description: 'Allows users to execute abritrary GraphQL requests.'
+  description: 'Allows users to execute arbitrary GraphQL requests.'
 
 'execute persisted graphql requests':
   title: 'Execute persisted GraphQL requests'


### PR DESCRIPTION
Fixes a small spelling mistake in `graphql.permissions.yml` file.