### PR TITLE
Allow to register resolvers via plugins.

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -103,6 +103,17 @@ services:
       - '\Drupal\graphql\Annotation\DataProducer'
       - '%graphql.config%'
 
+  plugin.manager.graphql.resolver_map:
+    class: Drupal\graphql\Plugin\ResolverMapPluginManager
+    arguments:
+      - 'Plugin/GraphQL/ResolverMap'
+      - '@container.namespaces'
+      - '@module_handler'
+      - '@cache.graphql.definitions'
+      - '\Drupal\graphql\Plugin\ResolverMapPluginInterface'
+      - '\Drupal\graphql\Annotation\ResolverMap'
+      - '%graphql.config%'
+
   # Buffers.
   graphql.buffer.entity:
     class: Drupal\graphql\GraphQL\Buffers\EntityBuffer

--- a/src/Annotation/ResolverMap.php
+++ b/src/Annotation/ResolverMap.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\graphql\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationException;
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a resolver map annotation object.
+ *
+ * Plugin Namespace: Plugin\ResolverMap
+ *
+ * @see \Drupal\graphql\Plugin\ResolverMapPluginInterface
+ * @see \Drupal\graphql\Plugin\ResolverMapPluginManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class ResolverMap extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The schema ID.
+   *
+   * @var string
+   */
+  public $schema;
+
+  /**
+   * ResolverMap constructor.
+   *
+   * @param $values
+   *   The plugin annotation values.
+   *
+   * @throws \Doctrine\Common\Annotations\AnnotationException
+   *   In case of missing required annotation values.
+   */
+  public function __construct($values) {
+    if (!array_key_exists('schema', $values) || !$values['schema']) {
+      throw new AnnotationException('The plugin is missing an "schema" property.');
+    }
+
+    parent::__construct($values);
+  }
+
+}

--- a/src/Annotation/ResolverMap.php
+++ b/src/Annotation/ResolverMap.php
@@ -43,7 +43,7 @@ class ResolverMap extends Plugin {
    */
   public function __construct($values) {
     if (!array_key_exists('schema', $values) || !$values['schema']) {
-      throw new AnnotationException('The plugin is missing an "schema" property.');
+      throw new AnnotationException('The plugin is missing a "schema" property.');
     }
 
     parent::__construct($values);

--- a/src/Plugin/ResolverMapPluginInterface.php
+++ b/src/Plugin/ResolverMapPluginInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\graphql\Plugin;
+
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistry;
+
+/**
+ * Defines the common interface for all resolver map plugins.
+ *
+ * @see \Drupal\graphql\Plugin\ResolverMapPluginManager
+ * @see \Drupal\graphql\Annotation\ResolverMap
+ * @see plugin_api
+ */
+interface ResolverMapPluginInterface {
+
+  /**
+   * Register field/type resolvers.
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverRegistry $registry
+   *   Resolver registry.
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   *   Resolver builder.
+   */
+  public function registerResolvers(ResolverRegistry $registry, ResolverBuilder $builder);
+
+}

--- a/src/Plugin/ResolverMapPluginManager.php
+++ b/src/Plugin/ResolverMapPluginManager.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\graphql\Plugin;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistry;
+
+/**
+ * Collects plugins that can add to or change the GraphQL resolver registry.
+ */
+class ResolverMapPluginManager extends DefaultPluginManager {
+
+  /**
+   * ResolverMapPluginManager constructor.
+   *
+   * @param bool|string $pluginSubdirectory
+   *   The plugin's subdirectory.
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cacheBackend
+   *   The cache backend.
+   * @param string|null $pluginInterface
+   *   The interface each plugin should implement.
+   * @param string $pluginAnnotationName
+   *   The name of the annotation that contains the plugin definition.
+   * @param array $config
+   *   The configuration service parameter.
+   */
+  public function __construct(
+    $pluginSubdirectory,
+    \Traversable $namespaces,
+    ModuleHandlerInterface $moduleHandler,
+    CacheBackendInterface $cacheBackend,
+    $pluginInterface,
+    $pluginAnnotationName,
+    array $config
+  ) {
+    parent::__construct(
+      $pluginSubdirectory,
+      $namespaces,
+      $moduleHandler,
+      $pluginInterface,
+      $pluginAnnotationName
+    );
+
+    $this->useCaches(empty($config['development']));
+    $this->setCacheBackend($cacheBackend, 'resolver_map');
+  }
+
+  /**
+   * Register resolvers for given schema.
+   *
+   * @param string $schema
+   *   GraphQL schema to get resolvers for.
+   * @param \Drupal\graphql\GraphQL\ResolverRegistry $registry
+   *   Optional. Resolver registry containing custom default settings.
+   *
+   * @return \Drupal\graphql\GraphQL\ResolverRegistry
+   *   Registry with registered field/type resolvers.
+   */
+  public function registerResolvers($schema, ResolverRegistry $registry = NULL) {
+    if (!$registry) {
+      $registry = new ResolverRegistry([]);
+    }
+    $builder = new ResolverBuilder();
+    foreach ($this->getDefinitions() as $plugin_id => $definition) {
+      if ($schema == $definition['schema']) {
+        /** @var \Drupal\graphql\Plugin\ResolverMapPluginInterface $plugin */
+        $plugin = $this->createInstance($plugin_id, $definition);
+        $plugin->registerResolvers($registry, $builder);
+      }
+    }
+    return $registry;
+  }
+
+}


### PR DESCRIPTION
PR introduces a way to register field/type resolvers across modules.

@fubhy recently we were solving the problem of distributing schema and fielt/type resolvers across modules. We tried several approaches, like caching whole ResolverRegistry object and some other ways, but all of them had some downsides. Finally we ended up with a solution in this PR.

Introduced plugins which may register field/type resolvers for particular schema. With this solution only plugin definitions are cached and the execution speed is (nearly) the same as building registry on run-time in schema object at on place. Because the execution workflow is pretty much the same.

And also, now the closures won't be a problem as well.

We'd love to hear your opinion, or your desired approach to that problem. Distribution across modules will be desired mostly for Drupal distributions where you want to extend schema or introduce new field type resolvers per distribution used.

Example of plugin which registers field resolvers:
```
/**
 * Registers auth field resolvers.
 *
 * @ResolverMap(
 *   id = "demo_auth_resolver_map",
 *   schema = "demo_schema",
 * )
 */
class AuthResolvers extends PluginBase implements ResolverMapPluginInterface {

  /**
   * {@inheritdoc}
   */
  public function registerResolvers(ResolverRegistry $registry, ResolverBuilder $builder) {
    $registry->addFieldResolver('Mutation', 'userLogin',
      $builder->produce('user_login', [
        'mapping' => [
          'email' => $builder->fromArgument('email'),
          'password' => $builder->fromArgument('password'),
        ],
      ])
    );
   ...
  }

}
```

Example of schema registering distributed resolvers:
```
/**
 * Demo GraphQL schema.
 *
 * @Schema(
 *   id = "demo_schema",
 *   name = "Demo schema"
 * )
 */
class SdlSchemaDemo extends SdlSchemaPluginBase {

  ...

  protected function getResolverRegistry() {
    $registry = new ResolverRegistry([], [
      __CLASS__,
      'defaultFieldResolver',
    ]);
    $registryMapManager = \Drupal::service('plugin.manager.graphql.resolver_map');
    return $registryMapManager->registerResolvers($this->getPluginId(), $registry);
  }

  ...
  
}
```