### PR TITLE
Translation fixes

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -266,7 +266,7 @@ services:
 
   graphql.language_context:
     class: Drupal\graphql\GraphQLLanguageContext
-    arguments: ['@language_manager']
+    arguments: ['@language_manager', '@string_translation']
 
   graphql.config_factory_override:
     class: Drupal\graphql\Config\GraphQLConfigOverrides

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Menu/MenuByName.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Menu/MenuByName.php
@@ -3,9 +3,8 @@
 namespace Drupal\graphql_core\Plugin\GraphQL\Fields\Menu;
 
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
-use Drupal\Core\Entity\EntityType;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
@@ -71,12 +70,6 @@ class MenuByName extends FieldPluginBase implements ContainerFactoryPluginInterf
     $entity = $this->entityTypeManager->getStorage('menu')->load($args['name']);
 
     if ($entity instanceof MenuInterface) {
-      if (isset($args['language']) && $args['language'] != $entity->language()->getId() && $entity instanceof TranslatableInterface && $entity->isTranslatable()) {
-        if ($entity->hasTranslation($args['language'])) {
-          $entity = $entity->getTranslation($args['language']);
-        }
-      }
-
       yield $entity;
     }
   }

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkDescription.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkDescription.php
@@ -15,7 +15,8 @@ use GraphQL\Type\Definition\ResolveInfo;
  *   secure = true,
  *   name = "description",
  *   type = "String",
- *   parents = {"MenuLink"}
+ *   parents = {"MenuLink"},
+ *   response_cache_contexts = {"languages:language_interface"}
  * )
  */
 class MenuLinkDescription extends FieldPluginBase {

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkLabel.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/MenuLink/MenuLinkLabel.php
@@ -15,7 +15,8 @@ use GraphQL\Type\Definition\ResolveInfo;
  *   secure = true,
  *   name = "label",
  *   type = "String",
- *   parents = {"MenuLink"}
+ *   parents = {"MenuLink"},
+ *   response_cache_contexts = {"languages:language_interface"}
  * )
  */
 class MenuLinkLabel extends FieldPluginBase {


### PR DESCRIPTION
Fixes included in this PR:
- the menu link description and label are now language aware (have the interface language in response cache context)
- the proper language is set for using the translation system, when executing a callable in a language context.
- the config override language is set, when executing a callable in a language context, so that config entities (like menus) are loaded using the proper translation.

This should fix: https://github.com/drupal-graphql/graphql/issues/773