### PR TITLE
New resolvers

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -145,6 +145,9 @@ services:
   graphql.buffer.entity:
     class: Drupal\graphql\GraphQL\Buffers\EntityBuffer
     arguments: ['@entity_type.manager']
+  graphql.buffer.entity_revision:
+    class: Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer
+    arguments: ['@entity_type.manager']
   graphql.buffer.entity_uuid:
     class: Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer
     arguments: ['@entity_type.manager']

--- a/src/GraphQL/Buffers/EntityRevisionBuffer.php
+++ b/src/GraphQL/Buffers/EntityRevisionBuffer.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\Buffers;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Entity revision buffer.
+ */
+class EntityRevisionBuffer extends BufferBase {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * EntityBuffer constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Add an item to the buffer.
+   *
+   * @param string $type
+   *   The entity type of the given entity ids.
+   * @param array|int $vid
+   *   The entity revision id(s) to load.
+   *
+   * @return \Closure
+   *   The callback to invoke to load the result for this buffer item.
+   */
+  public function add(string $type, $vid): \Closure {
+    $item = new \ArrayObject([
+      'type' => $type,
+      'vid' => $vid,
+    ]);
+
+    return $this->createBufferResolver($item);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getBufferId($item) {
+    return $item['type'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveBufferArray(array $buffer) {
+    $type = reset($buffer)['type'];
+    $vids = array_map(function (\ArrayObject $item) {
+      return (array) $item['vid'];
+    }, $buffer);
+
+    $vids = call_user_func_array('array_merge', $vids);
+    $vids = array_values(array_unique($vids));
+
+    // Load the buffered entities.
+    $entities = $this->entityTypeManager
+      ->getStorage($type)
+      ->loadMultipleRevisions($vids);
+
+    return array_map(function ($item) use ($entities) {
+      if (is_array($item['vid'])) {
+        return array_reduce($item['vid'], function ($carry, $current) use ($entities) {
+          if (!empty($entities[$current])) {
+            return $carry + [$current => $entities[$current]];
+          }
+
+          return $carry;
+        }, []);
+      }
+
+      return isset($entities[$item['vid']]) ? $entities[$item['vid']] : NULL;
+    }, $buffer);
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityQuery.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityQuery.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use GraphQL\Error\UserError;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Builds and executes Drupal entity query.
+ *
+ * @DataProducer(
+ *   id = "entity_query",
+ *   name = @Translation("Load entities"),
+ *   description = @Translation("Loads entities."),
+ *   produces = @ContextDefinition("entities",
+ *     label = @Translation("Entities")
+ *   ),
+ *   consumes = {
+ *     "type" = @ContextDefinition("string",
+ *       label = @Translation("Entity type")
+ *     ),
+ *     "limit" = @ContextDefinition("integer",
+ *       label = @Translation("Limit"),
+ *       required = FALSE
+ *     ),
+ *     "offset" = @ContextDefinition("integer",
+ *       label = @Translation("Offset"),
+ *       required = FALSE
+ *     ),
+ *     "conditions" = @ContextDefinition("any",
+ *       label = @Translation("Conditions"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Entity languages(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "bundles" = @ContextDefinition("any",
+ *       label = @Translation("Entity bundle(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class EntityQuery extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Maximum number of results.
+   *
+   * To prevent denial of service attacks with loading too many items.
+   */
+  const SIZE_MAX = 50;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    array $pluginDefinition,
+    EntityTypeManager $entityTypeManager
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Resolves the entity query.
+   *
+   * @param string $type
+   *   Entity type.
+   * @param int $limit
+   *   Maximum number of queried entities.
+   * @param int|null $offset
+   *   Offset to start with.
+   * @param array|null $conditions
+   *   List of conditions to filter the entities.
+   * @param string|null $language
+   *   Language of queried entities.
+   * @param array|null $bundles
+   *   List of bundles to be filtered.
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   The metadata object for caching.
+   *
+   * @return array
+   *   The list of ids that match this query.
+   *
+   * @throws \GraphQL\Error\UserError
+   *   No bundles defined for given entity type.
+   */
+  public function resolve(string $type, int $limit = 10, ?int $offset = NULL, ?array $conditions = NULL, ?string $language = NULL, ?array $bundles = NULL, RefinableCacheableDependencyInterface $metadata): array {
+
+    // Make sure that max limit is not crossed.
+    if ($limit > static::SIZE_MAX) {
+      $limit = static::SIZE_MAX;
+    }
+
+    // Make sure offset is zero or positive.
+    if (!isset($offset) || $offset < 0) {
+      $offset = 0;
+    }
+
+    $entity_type = $this->entityTypeManager->getStorage($type);
+    $query = $entity_type->getQuery()
+      ->range($offset, $limit);
+
+    // Ensure that access checking is performed on the query.
+    $query->accessCheck(TRUE);
+
+    if (isset($bundles)) {
+      $bundle_key = $entity_type->getEntityType()->getKey('bundle');
+      if (!$bundle_key) {
+        throw new UserError('No bundles defined for given entity type.');
+      }
+      $query->condition($bundle_key, $bundles, "IN");
+    }
+    if (isset($language)) {
+      $query->condition('langcode', $language);
+    }
+
+    foreach ($conditions as $condition) {
+      $operation = isset($condition['operator']) ? $condition['operator'] : NULL;
+      $query->condition($condition['field'], $condition['value'], $operation);
+    }
+
+    $ids = $query->execute();
+
+    return $ids;
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceRevisions.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceRevisions.php
@@ -57,7 +57,7 @@ class EntityReferenceRevisions extends DataProducerPluginBase implements Contain
   /**
    * The entity revision buffer service.
    *
-   * @var \Drupal\jobiqo_graphql\GraphQL\Buffers\EntityRevisionBuffer
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer
    */
   protected $entityRevisionBuffer;
 
@@ -72,7 +72,7 @@ class EntityReferenceRevisions extends DataProducerPluginBase implements Contain
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
-      $container->get('jobiqo_graphql.buffer.entity_revisions')
+      $container->get('graphql.buffer.entity_revision')
     );
   }
 
@@ -87,7 +87,7 @@ class EntityReferenceRevisions extends DataProducerPluginBase implements Contain
    *   The plugin definition array.
    * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
    *   The entity type manager service.
-   * @param \Drupal\jobiqo_graphql\GraphQL\Buffers\EntityRevisionBuffer $entityRevisionBuffer
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer $entityRevisionBuffer
    *   The entity revision buffer service.
    *
    * @codeCoverageIgnore

--- a/src/Plugin/GraphQL/DataProducer/Images/EntityReferenceRevisions.php
+++ b/src/Plugin/GraphQL/DataProducer/Images/EntityReferenceRevisions.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Field;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
+use GraphQL\Deferred;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Loads the entity reference revisions.
+ *
+ * @DataProducer(
+ *   id = "entity_reference_revisions",
+ *   name = @Translation("Entity reference revisions"),
+ *   description = @Translation("Loads entities from an entity reference revisions field."),
+ *   produces = @ContextDefinition("entity",
+ *     label = @Translation("Entity"),
+ *     multiple = TRUE
+ *   ),
+ *   consumes = {
+ *     "entity" = @ContextDefinition("entity",
+ *       label = @Translation("Parent entity")
+ *     ),
+ *     "field" = @ContextDefinition("string",
+ *       label = @Translation("Field name")
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Language"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "bundle" = @ContextDefinition("string",
+ *       label = @Translation("Entity bundle(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class EntityReferenceRevisions extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity revision buffer service.
+   *
+   * @var \Drupal\jobiqo_graphql\GraphQL\Buffers\EntityRevisionBuffer
+   */
+  protected $entityRevisionBuffer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('jobiqo_graphql.buffer.entity_revisions')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\jobiqo_graphql\GraphQL\Buffers\EntityRevisionBuffer $entityRevisionBuffer
+   *   The entity revision buffer service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    array $pluginDefinition,
+    EntityTypeManager $entityTypeManager,
+    EntityRevisionBuffer $entityRevisionBuffer
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityRevisionBuffer = $entityRevisionBuffer;
+  }
+
+  /**
+   * Resolves entity reference revisions for a given field of a given entity.
+   *
+   * May optionally respect the entity bundles and language.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $field
+   *   The field of a given entity to get entity reference revisions for.
+   * @param string|null $language
+   *   Optional. Language to be respected for retrieved entities.
+   * @param array|null $bundles
+   *   Optional. List of bundles to be respected for retrieved entities.
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   The metadata object for caching.
+   *
+   * @return \GraphQL\Deferred|null
+   *   A promise that will return entities or NULL if there aren't any.
+   */
+  public function resolve(EntityInterface $entity, string $field, ?string $language = NULL, ?array $bundles = NULL, RefinableCacheableDependencyInterface $metadata): ?Deferred {
+    if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
+      return NULL;
+    }
+
+    $definition = $entity->getFieldDefinition($field);
+    if ($definition->getType() !== 'entity_reference_revisions') {
+      return NULL;
+    }
+
+    $definition = $entity->getFieldDefinition($field);
+    $type = $definition->getSetting('target_type');
+    if (($values = $entity->get($field)) && $values instanceof EntityReferenceFieldItemListInterface) {
+      $vids = array_map(function ($value) {
+        return $value['target_revision_id'];
+      }, $values->getValue());
+
+      $resolver = $this->entityRevisionBuffer->add($type, $vids);
+      return new Deferred(function () use ($type, $language, $bundles, $resolver, $metadata) {
+        $entities = $resolver() ?: [];
+        $entities = array_filter($entities, function (EntityInterface $entity) use ($bundles) {
+          if (isset($bundles) && !in_array($entity->bundle(), $bundles)) {
+            return FALSE;
+          }
+
+          // Filter out also entity where access is missing.
+          $access = $entity->access('view', NULL, TRUE);
+          if (!$access->isAllowed()) {
+            return FALSE;
+          }
+
+          return TRUE;
+        });
+
+        if (empty($entities)) {
+          $type = $this->entityTypeManager->getDefinition($type);
+          /** @var \Drupal\Core\Entity\EntityTypeInterface $type */
+          $tags = $type->getListCacheTags();
+          $metadata->addCacheTags($tags);
+          return NULL;
+        }
+
+        if (isset($language)) {
+          $entities = array_map(function (EntityInterface $entity) use ($language) {
+            if ($language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+              return $entity->getTranslation($language);
+            }
+
+            return $entity;
+          }, $entities);
+        }
+
+        return $entities;
+      });
+    }
+
+    return NULL;
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
+++ b/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
@@ -1,0 +1,116 @@
+<?php
+
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Taxonomy;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Loads the taxonomy tree.
+ *
+ * @DataProducer(
+ *   id = "taxonomy_load_tree",
+ *   name = @Translation("Load multiple taxonomy terms"),
+ *   description = @Translation("Loads Taxonomy terms as a tree"),
+ *   produces = @ContextDefinition("taxonomy tree",
+ *     label = @Translation("Taxonomy tree")
+ *   ),
+ *   consumes = {
+ *     "vid" = @ContextDefinition("string",
+ *       label = @Translation("Vocabulary id")
+ *     ),
+ *     "parent" = @ContextDefinition("integer",
+ *       label = @Translation("The term ID under which to generate the tree"),
+ *       required = FALSE
+ *     ),
+ *     "max_depth" = @ContextDefinition("integer",
+ *       label = @Translation("Maximum tree depth"),
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class TaxonomyLoadTree extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The default max depth to search in taxonomy tree if it is not set.
+   */
+  const MAX_DEPTH = 10;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    array $pluginDefinition,
+    EntityTypeManager $entityTypeManager
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Resolves the taxonomy tree for given vocabulary.
+   *
+   * @param string $vid
+   *   The vocanulary ID.
+   * @param int $parent
+   *   The ID of the parent's term to load the tree for.
+   * @param int|null $max_depth
+   *   Max depth to search in.
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   Refinable cacheability metadata.
+   *
+   * @return \object[]
+   *   A list of stdClass terms in the given vocabulary.
+   */
+  public function resolve(string $vid, int $parent = 0, ?int $max_depth = NULL, RefinableCacheableDependencyInterface $metadata): array {
+    if (!isset($max_depth)) {
+      $max_depth = self::MAX_DEPTH;
+    }
+    // @todo This should use a buffer system similar to other entities are using.
+    $terms = $this->entityTypeManager
+      ->getStorage('taxonomy_term')
+      ->loadTree($vid, $parent, $max_depth);
+
+    return $terms;
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/User/CurrentUser.php
+++ b/src/Plugin/GraphQL/DataProducer/User/CurrentUser.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\User;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Gets the ID of current user.
+ *
+ * @DataProducer(
+ *   id = "current_user",
+ *   name = @Translation("Current user"),
+ *   description = @Translation("Current logged in user."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("Current user")
+ *   )
+ * )
+ */
+class CurrentUser extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * UserRegister constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * Returns current user id.
+   *
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $field_context
+   *   Field context.
+   *
+   * @return int
+   *   The current user id.
+   */
+  public function resolve(FieldContext $field_context) {
+    // Response must be cached based on current user as a cache context,
+    // otherwise a new user would became a previous user.
+    $field_context->addCacheableDependency($this->currentUser);
+    return (int) $this->currentUser->id();
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/User/CurrentUser.php
+++ b/src/Plugin/GraphQL/DataProducer/User/CurrentUser.php
@@ -67,7 +67,7 @@ class CurrentUser extends DataProducerPluginBase implements ContainerFactoryPlug
    * @return int
    *   The current user id.
    */
-  public function resolve(FieldContext $field_context) {
+  public function resolve(FieldContext $field_context): int {
     // Response must be cached based on current user as a cache context,
     // otherwise a new user would became a previous user.
     $field_context->addCacheableDependency($this->currentUser);


### PR DESCRIPTION
We'd like to move some of our custom data producers to graphql module:
- Current user
- Entity query
- Taxonomy load tree
- Entity reference revisions (including entity revision buffer)