### PR TITLE
#737 Add cache context to response_cache_contexts for ContextDeriver

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/Fields/ContextDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/ContextDeriver.php
@@ -44,6 +44,7 @@ class ContextDeriver extends DeriverBase implements ContainerDeriverInterface {
           'name' => StringHelper::propCase($id, 'context'),
           'context_id' => $id,
           'type' => $context->getContextDefinition()->getDataType(),
+          'response_cache_contexts' => $context->getCacheContexts(),
         ] + $basePluginDefinition;
       }
     }


### PR DESCRIPTION
It appears the `user` cache context is added in `\Drupal\user\ContextProvider\CurrentUserContext` but after that, it isn't added to the `response_cache_contexts` GQL field definition in `\Drupal\graphql_core\Plugin\Deriver\Fields\ContextDeriver`. 

This may lead to some unexpected caching of the `currentUserContext` field values. 
Suggested patch to include the cache context to the definition is attached.




