### PR TITLE
#771 null currentUserContext fix. Adjusts event subscriber weight

### DIFF
--- a/src/EventSubscriber/SubrequestSubscriber.php
+++ b/src/EventSubscriber/SubrequestSubscriber.php
@@ -29,7 +29,7 @@ class SubrequestSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    return [KernelEvents::REQUEST => 'onKernelRequest'];
+    return [KernelEvents::REQUEST => ['onKernelRequest', 100]];
   }
 
 }


### PR DESCRIPTION
Sometimes the `currentUserContext` can return `null` with some related error such as: 

```
"Call to undefined method Drupal\Core\Routing\LocalRedirectResponse::getResult()"
``` 
or
```
Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException: 
No route found for the specified format _graphql_subrequest. 
Supported formats: html. in Drupal\Core\Routing\RequestFormatRouteFilter->filter() 
(line 65 of /var/www/docroot/core/lib/Drupal/Core/Routing/RequestFormatRouteFilter.php)
```

<img width="917" alt="Screen Shot 2019-08-01 at 7 41 53 PM" src="https://user-images.githubusercontent.com/1858243/62275261-aef61380-b495-11e9-9358-7fcf538add8d.png">

The attached patch adjusts the weight ordering of the event subscriber callback, so the logic is added earlier to the request, fixing the issue in local testing.