### PR TITLE
Introduce query type without placeholder.

### DIFF
--- a/src/Plugin/GraphQL/Schema/ComposableSchema.php
+++ b/src/Plugin/GraphQL/Schema/ComposableSchema.php
@@ -41,10 +41,7 @@ class ComposableSchema extends SdlSchemaPluginBase implements ConfigurableInterf
         query: Query
       }
 
-      type Query {
-        # TODO: Remove placeholder field.
-        __placeholder: String
-      }
+      type Query
 GQL;
 
   }


### PR DESCRIPTION
Currently placeholder in Query type in ComposableSchema causes an error:
`Uncaught Error: Name "__placeholder" must not begin with "__", which is reserved by GraphQL introspection.`

It should be enough to introduce plain Query type without any additional types inside. At least works for us.