### PR TITLE
chore(travis): Use a newer Ubuntu base version to get newer PHP 7.3 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 7.2
   - 7.3
 
+services:
+  - mysql
+
 env:
   global:
     - DRUPAL_BUILD_DIR=$TRAVIS_BUILD_DIR/../drupal

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ dist: bionic
 
 php:
   - 7.2
-# PHP 7.3 testing is disabled for now because there is an error we cannot
-# reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
-# - 7.3
+  - 7.3
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 dist: bionic
 
 php:
-  - 7.2
   - 7.3
 
 services:
@@ -16,23 +15,6 @@ env:
     - TRAVIS=true
   matrix:
     - DRUPAL_CORE=8.7.x
-
-matrix:
-  # Don't wait for the allowed failures to build.
-  fast_finish: true
-  include:
-    - php: 7.2
-      env:
-        - DRUPAL_CORE=8.7.x
-        # Only run code coverage on the latest php and drupal versions.
-        - WITH_PHPDBG_COVERAGE=true
-  allow_failures:
-    # Allow the code coverage report to fail.
-    - php: 7.2
-      env:
-        - DRUPAL_CORE=8.7.x
-        # Only run code coverage on the latest php and drupal versions.
-        - WITH_PHPDBG_COVERAGE=true
 
 mysql:
   database: graphql
@@ -87,17 +69,4 @@ install:
   - composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade
 
 script:
-  # Run the unit tests using phpdbg if the environment variable is 'true'.
-  - if [[ "$WITH_PHPDBG_COVERAGE" == "true" ]];
-      then phpdbg -qrr $DRUPAL_BUILD_DIR/vendor/bin/phpunit --configuration $DRUPAL_BUILD_DIR/core/phpunit.xml --coverage-clover $TRAVIS_BUILD_DIR/coverage.xml $TRAVIS_BUILD_DIR;
-    fi
-
-  # Run the unit tests with standard php otherwise.
-  - if [[ "$WITH_PHPDBG_COVERAGE" != "true" ]];
-      then $DRUPAL_BUILD_DIR/vendor/bin/phpunit --configuration $DRUPAL_BUILD_DIR/core/phpunit.xml $TRAVIS_BUILD_DIR;
-    fi
-
-after_success:
-  - if [[ "$WITH_PHPDBG_COVERAGE" == "true" ]];
-      then bash <(curl -s https://codecov.io/bash);
-    fi
+  - $DRUPAL_BUILD_DIR/vendor/bin/phpunit --configuration $DRUPAL_BUILD_DIR/core/phpunit.xml $TRAVIS_BUILD_DIR/tests/src/Kernel/Framework/BufferedFieldTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: bionic
 
 php:
   - 7.2

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
          checkForUnintentionallyCoveredCode="false">
   <testsuites>
     <testsuite name="unit">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true"
          checkForUnintentionallyCoveredCode="false">
   <testsuites>
     <testsuite name="unit">

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -69,7 +69,7 @@ GQL;
         }, $items);
       });
 
-    /*$this->mockResolver('Query', 'users',
+    $this->mockResolver('Query', 'users',
       function ($parent, $args) use ($buffer) {
         $resolvers = array_map(function ($uid) use ($buffer) {
           return $buffer->createBufferResolver(new ArrayObject(['uid' => $uid]));
@@ -86,7 +86,7 @@ GQL;
       }
     );
 
-    $this->mockResolver('User', 'name',
+    /*$this->mockResolver('User', 'name',
       function ($parent) {
         return $parent['name'];
       }

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -116,7 +116,7 @@ GQL;
       }
     );
 
-    /*$query = $this->getQueryFromFile('batched.gql');
+    $query = $this->getQueryFromFile('batched.gql');
     $metadata = $this->defaultCacheMetaData();
     $this->assertResults($query, [], [
       'a' => [
@@ -134,7 +134,7 @@ GQL;
           'foe' => ['name' => 'E'],
         ],
       ],
-    ], $metadata);*/
+    ], $metadata);
   }
 
 }

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -61,7 +61,7 @@ GQL;
       'e' => ['name' => 'E'],
     ];
 
-    $buffer->expects(static::exactly(2))
+    $buffer
       ->method('resolveBufferArray')
       ->willReturnCallback(function ($items) use ($users) {
         return array_map(function ($item) use ($users) {
@@ -69,7 +69,7 @@ GQL;
         }, $items);
       });
 
-    $this->mockResolver('Query', 'users',
+    /*$this->mockResolver('Query', 'users',
       function ($parent, $args) use ($buffer) {
         $resolvers = array_map(function ($uid) use ($buffer) {
           return $buffer->createBufferResolver(new ArrayObject(['uid' => $uid]));
@@ -134,7 +134,7 @@ GQL;
           'foe' => ['name' => 'E'],
         ],
       ],
-    ], $metadata);
+    ], $metadata);*/
   }
 
 }

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -41,6 +41,8 @@ GQL;
 
   /**
    * Test if the schema is created properly.
+   *
+   * @preserveGlobalState disabled
    */
   public function testBatchedFields() {
     $buffer = $this->getMockBuilder(BufferBase::class)

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -41,8 +41,6 @@ GQL;
 
   /**
    * Test if the schema is created properly.
-   *
-   * @preserveGlobalState disabled
    */
   public function testBatchedFields() {
     $buffer = $this->getMockBuilder(BufferBase::class)

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -106,7 +106,7 @@ GQL;
       }
     );
 
-    /*$this->mockResolver('User', 'foe',
+    $this->mockResolver('User', 'foe',
       function ($parent) use ($buffer) {
         $resolver = $buffer->createBufferResolver(new ArrayObject(['uid' => $parent['foe']]));
 
@@ -116,7 +116,7 @@ GQL;
       }
     );
 
-    $query = $this->getQueryFromFile('batched.gql');
+    /*$query = $this->getQueryFromFile('batched.gql');
     $metadata = $this->defaultCacheMetaData();
     $this->assertResults($query, [], [
       'a' => [

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -86,13 +86,13 @@ GQL;
       }
     );
 
-    /*$this->mockResolver('User', 'name',
+    $this->mockResolver('User', 'name',
       function ($parent) {
         return $parent['name'];
       }
     );
 
-    $this->mockResolver('User', 'friends',
+    /*$this->mockResolver('User', 'friends',
       function ($parent) use ($buffer) {
         $resolvers = array_map(function ($uid) use ($buffer) {
           return $buffer->createBufferResolver(new ArrayObject(['uid' => $uid]));

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -92,7 +92,7 @@ GQL;
       }
     );
 
-    /*$this->mockResolver('User', 'friends',
+    $this->mockResolver('User', 'friends',
       function ($parent) use ($buffer) {
         $resolvers = array_map(function ($uid) use ($buffer) {
           return $buffer->createBufferResolver(new ArrayObject(['uid' => $uid]));
@@ -106,7 +106,7 @@ GQL;
       }
     );
 
-    $this->mockResolver('User', 'foe',
+    /*$this->mockResolver('User', 'foe',
       function ($parent) use ($buffer) {
         $resolver = $buffer->createBufferResolver(new ArrayObject(['uid' => $parent['foe']]));
 

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -90,8 +90,8 @@ trait QueryResultAssertionTrait {
     );
 
     $this->assertResultErrors($result, []);
-    /*$this->assertResultData($result, $expected);
-    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
+    $this->assertResultData($result, $expected);
+    /*$this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
   }
 
   /**

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -89,8 +89,8 @@ trait QueryResultAssertionTrait {
       ])
     );
 
-    /*$this->assertResultErrors($result, []);
-    $this->assertResultData($result, $expected);
+    $this->assertResultErrors($result, []);
+    /*$this->assertResultData($result, $expected);
     $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
   }
 

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -89,9 +89,9 @@ trait QueryResultAssertionTrait {
       ])
     );
 
-    /*$this->assertResultErrors($result, []);
+    $this->assertResultErrors($result, []);
     $this->assertResultData($result, $expected);
-    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
+    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());
   }
 
   /**

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -89,9 +89,9 @@ trait QueryResultAssertionTrait {
       ])
     );
 
-    $this->assertResultErrors($result, []);
+    //$this->assertResultErrors($result, []);
     $this->assertResultData($result, $expected);
-    /*$this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
+    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());
   }
 
   /**

--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -89,9 +89,9 @@ trait QueryResultAssertionTrait {
       ])
     );
 
-    $this->assertResultErrors($result, []);
+    /*$this->assertResultErrors($result, []);
     $this->assertResultData($result, $expected);
-    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());
+    $this->assertResultMetadata($result, $metadata ?: $this->defaultCacheMetaData());*/
   }
 
   /**


### PR DESCRIPTION
We have random fails on PHP 7.3. Could not reproduce locally, I have 7.3.7. Travis uses an old 7.3.2, let's try to upgrade Travis to make it run on newer versions.