### PR TITLE
fix(travis): Disable PHP 7.3 testing for now because it fails and we cannot reproduce the error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 php:
   - 7.2
-# PHP 7.3 testing is diabled for now because there is an error we cannot
+# PHP 7.3 testing is disabled for now because there is an error we cannot
 # reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
 # - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 
 php:
   - 7.2
-  - 7.3
+# PHP 7.3 testing is diabled for now because there is an error we cannot
+# reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
+# - 7.3
 
 env:
   global:


### PR DESCRIPTION
Sister issue of #872 

This should make our test runs green for now until we figure out the problem.