### PR TITLE
fix(travis): Allow failures instead of completely disabling PHP 7.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 
 php:
   - 7.2
-# PHP 7.3 testing is disabled for now because there is an error we cannot
-# reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
-# - 7.3
+  - 7.3
 
 env:
   global:
@@ -31,6 +29,10 @@ matrix:
         - DRUPAL_CORE=8.7.x
         # Only run code coverage on the latest php and drupal versions.
         - WITH_PHPDBG_COVERAGE=true
+    # PHP 7.3 testing is allowed to fail for now because there is an error we
+    # cannot reproduce locally.
+    # See https://github.com/drupal-graphql/graphql/pull/872
+    - php: 7.3
 
 mysql:
   database: graphql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 
 php:
   - 7.2
-# PHP 7.3 testing is disabled for now because there is an error we cannot
-# reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
-# - 7.3
+  - 7.3
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 php:
   - 7.2
-# PHP 7.3 testing is diabled for now because there is an error we cannot
+# PHP 7.3 testing is disabled for now because there is an error we cannot
 # reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
 # - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 
 php:
   - 7.2
-  - 7.3
+# PHP 7.3 testing is diabled for now because there is an error we cannot
+# reproduce locally. See https://github.com/drupal-graphql/graphql/pull/872
+# - 7.3
 
 env:
   global:


### PR DESCRIPTION
Sorry, #874 should have been actually this.

That way we also restore the 2 different PHP 7.2 runs, one for code coverage.

Let's see if this passes on Travis.