### PR TITLE
Fix strict PHP warnings after a fresh install.

### DIFF
--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -89,7 +89,15 @@ class ServerForm extends EntityForm {
     $schemas = array_map(function ($definition) {
       return $definition['name'] ?? $definition['id'];
     }, $this->schemaManager->getDefinitions());
-    $schema = ($formState->getUserInput()['schema'] ?: $server->get('schema')) ?: reset(array_keys($schemas));
+    $userInput = $formState->getUserInput();
+    $schemaKeys = array_keys($schemas);
+    if (isset($userInput['schema'])) {
+        $schema = $userInput['schema'];
+    } elseif (!empty($server->get('schema'))) {
+        $schema = $server->get('schema');
+    } else {
+        $schema = reset($schemaKeys);
+    }
 
     if ($this->operation == 'add') {
       $form['#title'] = $this->t('Add server');

--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -89,16 +89,8 @@ class ServerForm extends EntityForm {
     $schemas = array_map(function ($definition) {
       return $definition['name'] ?? $definition['id'];
     }, $this->schemaManager->getDefinitions());
-    $userInput = $formState->getUserInput();
-    $schemaKeys = array_keys($schemas);
-    if (isset($userInput['schema'])) {
-        $schema = $userInput['schema'];
-    } elseif (!empty($server->get('schema'))) {
-        $schema = $server->get('schema');
-    } else {
-        $schema = reset($schemaKeys);
-    }
-
+    
+    $schema = ($formState->getUserInput()['schema'] ?? $server->get('schema')) ?: reset(array_keys($schemas));
     if ($this->operation == 'add') {
       $form['#title'] = $this->t('Add server');
     }

--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -89,8 +89,8 @@ class ServerForm extends EntityForm {
     $schemas = array_map(function ($definition) {
       return $definition['name'] ?? $definition['id'];
     }, $this->schemaManager->getDefinitions());
-    
     $schema = ($formState->getUserInput()['schema'] ?? $server->get('schema')) ?: reset(array_keys($schemas));
+
     if ($this->operation == 'add') {
       $form['#title'] = $this->t('Add server');
     }

--- a/src/Plugin/GraphQL/Schema/ComposableSchema.php
+++ b/src/Plugin/GraphQL/Schema/ComposableSchema.php
@@ -77,6 +77,7 @@ GQL;
       '#type' => 'checkboxes',
       '#required' => FALSE,
       '#title' => t('Enabled extensions'),
+      '#options' => [],
       '#default_value' => $this->configuration['extensions'] ?? [],
     );
 


### PR DESCRIPTION
After a fresh install of the module, the create server form has a few errors and warnings.

```
Notice: Undefined index: schema in Drupal\graphql\Form\ServerForm->form() (line 92 of modules/contrib/graphql/src/Form/ServerForm.php).
Drupal\graphql\Form\ServerForm->form(Array, Object) (Line: 117)
```

```
Notice: Only variables should be passed by reference in Drupal\graphql\Form\ServerForm->form() (line 92 of modules/contrib/graphql/src/Form/ServerForm.php).
Drupal\graphql\Form\ServerForm->form(Array, Object) (Line: 117)
```

```
Notice: Undefined index: #options in Drupal\Core\Render\Element\Checkboxes::processCheckboxes() (line 58 of core/lib/Drupal/Core/Render/Element/Checkboxes.php).
```

```
Warning: count(): Parameter must be an array or an object that implements Countable in Drupal\Core\Render\Element\Checkboxes::processCheckboxes() (line 58 of core/lib/Drupal/Core/Render/Element/Checkboxes.php).
```