### PR TITLE
Add support for QueryComplexity validation rule.

### DIFF
--- a/src/GraphQL/Execution/QueryProcessor.php
+++ b/src/GraphQL/Execution/QueryProcessor.php
@@ -26,6 +26,7 @@ use GraphQL\Utils\TypeInfo;
 use GraphQL\Utils\Utils;
 use GraphQL\Validator\Rules\AbstractValidationRule;
 use GraphQL\Validator\ValidationContext;
+use GraphQL\Validator\Rules\QueryComplexity;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 // TODO: Refactor this and clean it up.
@@ -350,7 +351,12 @@ class QueryProcessor {
     $schema = $config->getSchema();
     $info = new TypeInfo($schema);
     $validation = new ValidationContext($schema, $document, $info);
-    $visitors = array_values(array_map(function (AbstractValidationRule $rule) use ($validation) {
+    $visitors = array_values(array_map(function (AbstractValidationRule $rule) use ($validation, $params) {
+      // Set current variable values for QueryComplexity validation rule case
+      // @see \GraphQL\GraphQL::promiseToExecute for equivalent
+      if ($rule instanceof QueryComplexity && !empty($params->variables)) {
+        $rule->setRawVariableValues($params->variables);
+      }
       return $rule($validation);
     }, $rules));
 


### PR DESCRIPTION
Currently if enabling the [`QueryComplexity` ](https://github.com/webonyx/graphql-php/blob/master/docs/security.md#query-complexity-analysis) validation rule for a GQL schema, the variable values are not passed and all queries fail, with an error such as

```
{
  "errors": [
    {
      "message": "Variable \"$uid\" of required type \"String!\" was not provided.",
      "category": "graphql"
    }
  ]
}
```

The base webonyx GQL class has some special logic to pass the request variables during validation for this case, in [`\GraphQL\GraphQL::promiseToExecute`](https://github.com/webonyx/graphql-php/blob/c45fa1a4b189c4356b21eed8a364165b8214eeb3/src/GraphQL.php#L137)

This patch adds the same approach to the Drupal 8 GraphQL module query processor validation step, to allow using the `QueryComplexity` validation rule.