### PR TITLE
Use EntityTypeManagerInterface instead of EntityTypeManager class directly.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -3,7 +3,7 @@
 namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
 
 use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
@@ -45,7 +45,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
   /**
    * The entity type manager service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -88,7 +88,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    *   The plugin id.
    * @param array $pluginDefinition
    *   The plugin definition array.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
    *   The entity repository service.
@@ -101,7 +101,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
     $configuration,
     $pluginId,
     $pluginDefinition,
-    EntityTypeManager $entityTypeManager,
+    EntityTypeManagerInterface $entityTypeManager,
     EntityRepositoryInterface $entityRepository,
     EntityBuffer $entityBuffer
   ) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -3,7 +3,7 @@
 namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
 
 use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql\GraphQL\Buffers\EntityUuidBuffer;
@@ -45,7 +45,7 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
   /**
    * The entity type manager service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -88,7 +88,7 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
    *   The plugin id.
    * @param array $pluginDefinition
    *   The plugin definition array.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
    *   The entity repository service.
@@ -101,7 +101,7 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
     $configuration,
     $pluginId,
     $pluginDefinition,
-    EntityTypeManager $entityTypeManager,
+    EntityTypeManagerInterface $entityTypeManager,
     EntityRepositoryInterface $entityRepository,
     EntityUuidBuffer $entityBuffer
   ) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -3,7 +3,7 @@
 namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
 
 use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
@@ -46,7 +46,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
   /**
    * The entity type manager service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -89,7 +89,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
    *   The plugin id.
    * @param array $pluginDefinition
    *   The plugin definition array.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
    *   The entity repository service.
@@ -102,7 +102,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
     $configuration,
     $pluginId,
     $pluginDefinition,
-    EntityTypeManager $entityTypeManager,
+    EntityTypeManagerInterface $entityTypeManager,
     EntityRepositoryInterface $entityRepository,
     EntityBuffer $entityBuffer
   ) {

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -91,7 +91,7 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
    *   The plugin id.
    * @param array $pluginDefinition
    *   The plugin definition array.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
    *   The entity repository service.
@@ -104,7 +104,7 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
     $configuration,
     $pluginId,
     $pluginDefinition,
-    EntityTypeManager $entityTypeManager,
+    EntityTypeManagerInterface $entityTypeManager,
     EntityRepositoryInterface $entityRepository,
     EntityBuffer $entityBuffer
   ) {


### PR DESCRIPTION
4.x breaks with other contrib that swap out the EntityTypeManager without inheriting. Specifically devel's webprofiler module.

`Argument 4 passed to Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\EntityLoad::__construct() must be an instance of Drupal\Core\Entity\EntityTypeManager, instance of Drupal\webprofiler\Entity\EntityManagerWrapper given, called in \xxx\web\modules\graphql\src\Plugin\GraphQL\DataProducer\Entity\EntityLoad.php on line 78`