### PR TITLE
4x: fix path prefix being dropped

### DIFF
--- a/src/RouteProvider.php
+++ b/src/RouteProvider.php
@@ -64,7 +64,7 @@ class RouteProvider {
         ->addOptions([
           '_auth' => $auth,
           'no_cache' => TRUE,
-          'default_url_options' => ['path_processing' => FALSE],
+          'default_url_options' => ['path_processing' => TRUE],
           'parameters' => ['graphql_server' => ['type' => 'entity:graphql_server']]
         ]);
     }


### PR DESCRIPTION
My site has both a country code prefix and a language prefix. eg: `example.com/us/en`
The `graphqlRequestUrl` in `drupalSettings` only contained the path prefix, and was dropping the language prefix. This was breaking language detection in my resolvers when using the GQL explorer page.
This was my solution.