### PR TITLE
Accomodate for arrays in MenuLinkAttribute data producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkAttribute.php
+++ b/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkAttribute.php
@@ -36,7 +36,13 @@ class MenuLinkAttribute extends DataProducerPluginBase {
    */
   public function resolve(MenuLinkInterface $link, $attribute) {
     $options = $link->getOptions();
-    return NestedArray::getValue($options, ['attributes', $attribute]);
+    // Certain attributes like class can be arrays. Check for that and implode them.
+    $attributeValue = NestedArray::getValue($options, ['attributes', $attribute]);
+    if (is_array($attributeValue)) {
+      return implode(" ", $attributeValue);
+    } else {
+      return $attributeValue;
+    }
   }
 
 }


### PR DESCRIPTION
Certain attributes like class can be arrays. Check for that and implode them.
This was fixed in 8.x-3.x here: https://github.com/drupal-graphql/graphql/pull/687/files