### PR TITLE
Fix entity load arguments

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -131,7 +131,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    * @param $type
    * @param $id
    * @param null $language
-   * @param null $bundles
+   * @param array|null $bundles
    * @param bool $access
    * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
    * @param string $accessOperation
@@ -139,7 +139,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $id, $language, $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve($type, $id, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $id);
 
     return new Deferred(function () use ($type, $id, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -132,7 +132,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
    * @param $type
    * @param array $ids
    * @param null $language
-   * @param array|NULL $bundles
+   * @param array|null $bundles
    * @param bool $access
    * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
    * @param string $accessOperation

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -140,7 +140,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, array $ids, $language, array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve($type, array $ids, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $ids);
 
     return new Deferred(function () use ($type, $ids, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {


### PR DESCRIPTION
Noticed that `$bundle` argument cannot be null for `EntityLoadMultiple` data producer. Fixed it in this PR.

Also synced `$bundle` argument for  `EntityLoad` as well so they are defined same way.