### PR TITLE
EntityFieldPropertyDeriver overrides parents

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldPropertyDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldPropertyDeriver.php
@@ -21,8 +21,13 @@ class EntityFieldPropertyDeriver extends EntityFieldDeriverBase {
       $entityType = $this->entityTypeManager->getDefinition($entityTypeId);
       $supportsBundles = $entityType->hasKey('bundle');
 
+      if (!isset($basePluginDefinition['parents'])) {
+        $basePluginDefinition['parents'] = [];
+      }
+
+      $parents = [StringHelper::camelCase('field', $entityTypeId, $supportsBundles ? $fieldBundle : '', $fieldName)];
       return ["$entityTypeId-$fieldBundle-$fieldName" => [
-        'parents' => [StringHelper::camelCase('field', $entityTypeId, $supportsBundles ? $fieldBundle : '', $fieldName)],
+        'parents' => array_merge($parents, $basePluginDefinition['parents']),
       ] + $basePluginDefinition];
     }
 


### PR DESCRIPTION
EntityFieldPropertyDeriver overrides the parents defined in the GraphQLField-annotation. In RC2, the parents defined in the annotation were added to the array instead of overridden.