### PR TITLE
Refactor entity buffer resolver so that duplicate entity IDs are not dropped

### DIFF
--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -67,7 +67,6 @@ class EntityBuffer extends BufferBase {
       ->getStorage($type)
       ->loadMultiple($ids);
 
-
     $result = [];
     foreach ($buffer as $item) {
       if (is_array($item['id'])) {

--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -74,7 +74,7 @@ class EntityBuffer extends BufferBase {
           $result[] = $entities[$id];
         }
       } else {
-        $result[] = $entities[$item['id']];
+        $result = $entities[$item['id']];
       }
     }
     return [$result];

--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -67,19 +67,18 @@ class EntityBuffer extends BufferBase {
       ->getStorage($type)
       ->loadMultiple($ids);
 
-    return array_map(function ($item) use ($entities) {
+
+    $result = [];
+    foreach ($buffer as $item) {
       if (is_array($item['id'])) {
-        return array_reduce($item['id'], function ($carry, $current) use ($entities) {
-          if (!empty($entities[$current])) {
-            return $carry + [$current => $entities[$current]];
-          }
-
-          return $carry;
-        }, []);
+        foreach ($item['id'] as $id) {
+          $result[] = $entities[$id];
+        }
+      } else {
+        $result = $entities[$item['id']];
       }
-
-      return isset($entities[$item['id']]) ? $entities[$item['id']] : NULL;
-    }, $buffer);
+    }
+    return [$result];
   }
 
 }

--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -71,7 +71,8 @@ class EntityBuffer extends BufferBase {
       if (is_array($item['id'])) {
         return array_reduce($item['id'], function ($carry, $current) use ($entities) {
           if (!empty($entities[$current])) {
-            return $carry + [count($carry) => $entities[$current]];
+            array_push($carry, $entities[$current]);
+            return $carry;
           }
 
           return $carry;

--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -74,7 +74,7 @@ class EntityBuffer extends BufferBase {
           $result[] = $entities[$id];
         }
       } else {
-        $result = $entities[$item['id']];
+        $result[] = $entities[$item['id']];
       }
     }
     return [$result];

--- a/src/GraphQL/Buffers/EntityBuffer.php
+++ b/src/GraphQL/Buffers/EntityBuffer.php
@@ -67,17 +67,19 @@ class EntityBuffer extends BufferBase {
       ->getStorage($type)
       ->loadMultiple($ids);
 
-    $result = [];
-    foreach ($buffer as $item) {
+    return array_map(function ($item) use ($entities) {
       if (is_array($item['id'])) {
-        foreach ($item['id'] as $id) {
-          $result[] = $entities[$id];
-        }
-      } else {
-        $result = $entities[$item['id']];
+        return array_reduce($item['id'], function ($carry, $current) use ($entities) {
+          if (!empty($entities[$current])) {
+            return $carry + [count($carry) => $entities[$current]];
+          }
+
+          return $carry;
+        }, []);
       }
-    }
-    return [$result];
+
+      return isset($entities[$item['id']]) ? $entities[$item['id']] : NULL;
+    }, $buffer);
   }
 
 }


### PR DESCRIPTION
When you reference an entity multiple times in the same field, the `array_reduce` seems to drop the duplicates.