### PR TITLE
Allow to obtain field name property from field context.

### DIFF
--- a/src/GraphQL/Execution/FieldContext.php
+++ b/src/GraphQL/Execution/FieldContext.php
@@ -34,6 +34,13 @@ class FieldContext implements RefinableCacheableDependencyInterface {
   /**
    * @return string
    */
+  public function getFieldName() {
+    return $this->info->fieldName;
+  }
+
+  /**
+   * @return string
+   */
   public function getContextLanguage() {
     return $this->context->getContextLanguage();
   }


### PR DESCRIPTION
This would be a useful info to get as it is kind of context which could be used in data producers. I can illustrate it on one of our data producers.

We have data producer doing search api solr query:
```
// Search API jobs query.
$registry->addFieldResolver('Query', 'jobs', $builder->compose(
  $builder->context('search_id', $builder->fromValue('jobs_search')),
  $builder->produce('search_api_load', [
    'index_id' => $builder->fromValue('job_search'),
    'language' => $builder->fromArgument('language'),
    'range' => $builder->fromArgument('ranges'),
    'sort' => $builder->fromValue([]),
    'fulltext' => $builder->fromArgument('fulltext'),
  ])
));
```

After execuion of search api query we do some alters to solarium query to use some specific solr features which cannot be used within SearchApiQuery object. We do that in `hook_search_api_solr_query_alter`. Our data producer sets search id so it's easily target-able in that hook:
```
// Set search id context to the query so it's easily target-able.
if ($search_id = $context->getContextValue('search_id')) {
  $this->query->setSearchId($search_id);
}
```

This would be much easier if we could obtain `fieldName` property of resolve info within `FieldContext` because it's unique. So instead of creating some custom context we'd just use this:
```
    $query->setSearchId($fieldContext->getFieldName());
```

This PR should make it possible.