### PR TITLE
Fix a typo on permissions for voyager

### DIFF
--- a/src/PermissionProvider.php
+++ b/src/PermissionProvider.php
@@ -51,7 +51,7 @@ class PermissionProvider {
         'description' => $this->t('Allows users use the explorer interface.', $params),
       ];
 
-      $permissions["execute $id graphql voyager"] = [
+      $permissions["use $id graphql voyager"] = [
         'title' => $this->t('%name: Use voyager', $params),
         'description' => $this->t('Allows users to use the voyager interface.', $params),
       ];


### PR DESCRIPTION
There is a typo on this file that doesn't match with the VoyagerAccessCheck therefore we are not able to allow roles to use Voyager.