### PR TITLE
Mark entity query as "insecure"

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
@@ -37,6 +37,10 @@ use GraphQL\Type\Definition\ResolveInfo;
  *   },
  *   deriver = "Drupal\graphql_core\Plugin\Deriver\Fields\EntityQueryDeriver"
  * )
+ *
+ * This field is marked as not secure because it does not enforce entity field
+ * access over a chain of filters. For example node.uid.pass could be used as
+ * filter input which would disclose information about Drupal's password hashes.
  */
 class EntityQuery extends FieldPluginBase implements ContainerFactoryPluginInterface {
   use DependencySerializationTrait;

--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/EntityQuery/EntityQuery.php
@@ -17,7 +17,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 /**
  * @GraphQLField(
  *   id = "entity_query",
- *   secure = true,
+ *   secure = false,
  *   type = "EntityQueryResult",
  *   arguments = {
  *     "filter" = "EntityQueryFilterInput",

--- a/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
+++ b/modules/graphql_core/tests/src/Kernel/EntityQuery/EntityQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\graphql_core\Kernel\EntityQuery;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Tests\graphql_core\Kernel\GraphQLContentTestBase;
 
 /**
@@ -104,6 +105,28 @@ class EntityQueryTest extends GraphQLContentTestBase {
         ],
         'count' => 4,
       ],
+    ], $metadata);
+  }
+
+  /**
+   * Make sure entity filters are properly secured.
+   */
+  public function testFilterSecurity() {
+    $metadata = new CacheableMetadata();
+    $metadata->addCacheContexts([
+      'languages:language_content',
+      'languages:language_interface',
+      'languages:language_url',
+      'user.permissions',
+    ]);
+    $metadata->addCacheTags(['graphql', 'user_list']);
+    $this->assertResults('query { userQuery (filter: { conditions: [ { field: "pass", value: "foo" } ] }) { count } }', [], [
+      'userQuery' => [
+        // TODO: With proper access checking for filters this value should
+        //       become "2" and the entity query field can be marked as secure
+        //       again.
+        'count' => 0,
+      ]
     ], $metadata);
   }
 


### PR DESCRIPTION
This is an alternative solution to #877 . Just restricting the operators is not enough since it still allows to expose information. JSON:API has a subsystem for securing entity field queries, but switching there is a non trivial task.

User can either create a save environment and still use this query or rely on the `graphql_views` module for entity listings instead.