### PR TITLE
Add dimensions for images

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
@@ -45,10 +45,23 @@ class ImageDerivative extends DataProducerPluginBase {
     $access = $entity->access('view', NULL, TRUE);
     $metadata->addCacheableDependency($access);
     if ($access->isAllowed() && $image_style = ImageStyle::load($style)) {
+
+      $width = $entity->width;
+      $height = $entity->height;
+
+      if (empty($width) || empty($height)) {
+        /** @var \Drupal\Core\Image\ImageInterface $image */
+        $image = \Drupal::service('image.factory')->get($entity->getFileUri());
+        if ($image->isValid()) {
+          $width = $image->getWidth();
+          $height = $image->getHeight();
+        }
+      }
+
       // Determine the dimensions of the styled image.
       $dimensions = [
-        'width' => $entity->width,
-        'height' => $entity->height,
+        'width' => $width,
+        'height' => $height,
       ];
 
       $image_style->transformDimensions($dimensions, $entity->getFileUri());


### PR DESCRIPTION
By default Drupal doesn't provide dimensions for files entities. This information is saved at the field level. In order to have dimensions when we request derivatives, we need to get those values to fill the height and width for a given image like this we will get the calculated dimensions for the style requested.