### PR TITLE
Create .gql Query provider

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -64,6 +64,11 @@ services:
     arguments: ['@cache.default', '@config.factory']
     tags:
         - { name: graphql_query_provider }
+  graphql.query_provider.query_map.gql:
+    class: Drupal\graphql\GraphQL\QueryProvider\GqlQueryMapQueryProvider
+    arguments: ['@cache.default', '@config.factory']
+    tags:
+      - { name: graphql_query_provider }
 
   graphql.query_routes:
     class: Drupal\graphql\Routing\QueryRoutes

--- a/src/Form/JsonQueryMapConfigForm.php
+++ b/src/Form/JsonQueryMapConfigForm.php
@@ -78,6 +78,7 @@ class JsonQueryMapConfigForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->cacheBackend->delete('graphql_query_map_json_versions');
+    $this->cacheBackend->delete('graphql_query_map_gql_versions');
 
     $paths = array_map('trim', explode("\n", $form_state->getValue('lookup_paths', '')));
     $this->config('graphql.query_map_json.config')

--- a/src/GraphQL/QueryProvider/GqlQueryMapQueryProvider.php
+++ b/src/GraphQL/QueryProvider/GqlQueryMapQueryProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\graphql\GraphQL\QueryProvider;
+
+use Drupal\Component\FileSystem\RegexDirectoryIterator;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use GraphQL\Server\OperationParams;
+
+class GqlQueryMapQueryProvider implements QueryProviderInterface {
+
+  /**
+   * The cache backend for storing query map file paths.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
+  /**
+   * The paths to use for finding query maps.
+   *
+   * @var string[]
+   */
+  protected $lookupPaths;
+
+  /**
+   * QueryProvider constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cacheBackend
+   *   The cache backend for storing query map file paths.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(CacheBackendInterface $cacheBackend, ConfigFactoryInterface $configFactory) {
+    $this->lookupPaths = $configFactory->get('graphql.query_map_json.config')->get('lookup_paths') ?: [];
+    $this->cacheBackend = $cacheBackend;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuery($id, OperationParams $operation) {
+    // Check that the id is properly formatted.
+    if (empty($id)) {
+      return NULL;
+    }
+
+    if (!(($cache = $this->cacheBackend->get('graphql_query_map_gql_versions')) && ($versions = $cache->data) !== NULL)) {
+      $this->cacheBackend->set('graphql_query_map_gql_versions', $versions = $this->discoverQueryMaps());
+    }
+
+    if (isset($versions) && isset($versions[$id]) && file_exists($versions[$id])) {
+      return file_get_contents($versions[$id]);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Discovers the available query maps within the configured lookup paths.
+   *
+   * @return array
+   *   An associative array of query maps with the query map versions as keys.
+   */
+  protected function discoverQueryMaps() {
+    $maps = [];
+    foreach ($this->lookupPaths as $path) {
+      if (is_dir($path)) {
+        $iterator = new RegexDirectoryIterator($path, '/\.gql/i');
+
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+          $filename = $file->getBasename('.gql');
+          $maps[$filename] = $file->getPathname();
+        }
+      }
+
+      if (is_file($path)) {
+        $file = new \SplFileInfo($path);
+        $filename = $file->getBasename('.gql');
+        $maps[$filename] = $file->getPathname();
+      }
+    }
+
+    return $maps;
+  }
+}


### PR DESCRIPTION
This is a .gql version of the query provider. This will allow you to add your query as a straight text file with the extension of .gql which make it a lot easier to maintain and allow for documenting much easier.