### PR TITLE
Drop support for EOL Drupal 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php:
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - SIMPLETEST_DB=mysql://root:@127.0.0.1/graphql
     - TRAVIS=true
   matrix:
-    - DRUPAL_CORE=8.6.x
     - DRUPAL_CORE=8.7.x
     - DRUPAL_CORE=8.8.x
 
@@ -87,15 +86,15 @@ install:
   # require also triggers a full 'composer install'.
   - composer --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.12.5
 
-  # For Drupal < 8.8 we have to manually upgrade zend-stdlib to avoid PHP 7.3
+  # For Drupal 8.7 we have to manually upgrade zend-stdlib to avoid PHP 7.3
   # incompatibilities.
-  - if [[ "$DRUPAL_CORE" = "8.6.x" || "$DRUPAL_CORE" = "8.7.x" ]];
+  - if [[ "$DRUPAL_CORE" = "8.7.x" ]];
       then composer --working-dir=$DRUPAL_BUILD_DIR require zendframework/zend-stdlib:3.2.1;
     fi
 
-  # For Drupal < 8.8 we have to manually upgrade phpunit to avoid PHP 7.3
+  # For Drupal 8.7 we have to manually upgrade phpunit to avoid PHP 7.3
   # incompatibilities.
-  - if [[ "$DRUPAL_CORE" = "8.6.x" || "$DRUPAL_CORE" = "8.7.x" ]];
+  - if [[ "$DRUPAL_CORE" = "8.7.x" ]];
       then composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade;
     fi
 


### PR DESCRIPTION

**December 4, 2019:** 8.8.0 released. End of security support for 8.6.x.

![image](https://user-images.githubusercontent.com/1324225/70917883-cd187680-2026-11ea-85eb-430849bcb226.png)

https://www.drupal.org/core/release-cycle-overview

---

Should there also be a minimum Drupal core requirement in `composer.json` or somewhere?
