### PR TITLE
Update Path Alias API deprecations

### DIFF
--- a/modules/graphql_core/src/Plugin/GraphQL/Fields/Routing/InternalUrl/Alias.php
+++ b/modules/graphql_core/src/Plugin/GraphQL/Fields/Routing/InternalUrl/Alias.php
@@ -4,7 +4,7 @@ namespace Drupal\graphql_core\Plugin\GraphQL\Fields\Routing\InternalUrl;
 
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
@@ -29,7 +29,7 @@ class Alias extends FieldPluginBase implements ContainerFactoryPluginInterface {
   /**
    * Instance of an alias manager.
    *
-   * @var \Drupal\Core\Path\AliasManagerInterface
+   * @var \Drupal\path_alias\AliasManagerInterface
    */
   protected $aliasManager;
 
@@ -41,7 +41,7 @@ class Alias extends FieldPluginBase implements ContainerFactoryPluginInterface {
       $configuration,
       $pluginId,
       $pluginDefinition,
-      $container->get('path.alias_manager')
+      $container->get('path_alias.manager')
     );
   }
 
@@ -54,7 +54,7 @@ class Alias extends FieldPluginBase implements ContainerFactoryPluginInterface {
    *   The plugin id.
    * @param mixed $pluginDefinition
    *   The plugin definition.
-   * @param \Drupal\Core\Path\AliasManagerInterface $aliasManager
+   * @param \Drupal\path_alias\AliasManagerInterface $aliasManager
    *   The alias manager service
    */
   public function __construct(

--- a/modules/graphql_core/tests/src/Kernel/Routing/RouteTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Routing/RouteTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\graphql_core\Kernel\Routing;
 
 use Drupal\Core\GeneratedUrl;
-use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Tests\graphql_core\Kernel\GraphQLCoreTestBase;
 use Prophecy\Argument;
@@ -39,7 +39,7 @@ class RouteTest extends GraphQLCoreTestBase {
       ->generateFromRoute('graphql_context_test.a', [], ['query' => []], TRUE)
       ->willReturn((new GeneratedUrl())->setGeneratedUrl('/my/other/alias'));
 
-    $this->container->set('path.alias_manager', $aliasManager->reveal());
+    $this->container->set('path_alias.manager', $aliasManager->reveal());
     $this->container->set('url_generator', $urlGenerator->reveal());
   }
 


### PR DESCRIPTION
These are deprecated in Drupal 8.8.

https://www.drupal.org/node/3092086

Obviously this will fail in Drupal 8.7 (and 8.6 but it's EOL, see PR #958).

I see these aren't used in the 4.x branch. Would this be useful for the 3.x branch, and if so, how would you like the version checking to be done?