### PR TITLE
Added entity reference layout revisions plugin.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceLayoutRevisions.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceLayoutRevisions.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Field;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
+use GraphQL\Deferred;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Loads the entity reference layout revisions.
+ *
+ * @DataProducer(
+ *   id = "entity_reference_layout_revisions",
+ *   name = @Translation("Entity reference layout revisions"),
+ *   description = @Translation("Loads entities from an entity reference layout revisions field."),
+ *   provider = "entity_reference_layout",
+ *   produces = @ContextDefinition("entity",
+ *     label = @Translation("Entity"),
+ *     multiple = TRUE
+ *   ),
+ *   consumes = {
+ *     "entity" = @ContextDefinition("entity",
+ *       label = @Translation("Parent entity")
+ *     ),
+ *     "field" = @ContextDefinition("string",
+ *       label = @Translation("Field name")
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Language"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "bundle" = @ContextDefinition("string",
+ *       label = @Translation("Entity bundle(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "access" = @ContextDefinition("boolean",
+ *       label = @Translation("Check access"),
+ *       required = FALSE,
+ *       default_value = TRUE
+ *     ),
+ *     "access_user" = @ContextDefinition("entity:user",
+ *       label = @Translation("User"),
+ *       required = FALSE,
+ *       default_value = NULL
+ *     ),
+ *     "access_operation" = @ContextDefinition("string",
+ *       label = @Translation("Operation"),
+ *       required = FALSE,
+ *       default_value = "view"
+ *     )
+ *   }
+ * )
+ */
+class EntityReferenceLayoutRevisions extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity revision buffer service.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer
+   */
+  protected $entityRevisionBuffer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('graphql.buffer.entity_revision')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer $entityRevisionBuffer
+   *   The entity revision buffer service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    array $pluginDefinition,
+    EntityTypeManager $entityTypeManager,
+    EntityRevisionBuffer $entityRevisionBuffer
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityRevisionBuffer = $entityRevisionBuffer;
+  }
+
+  /**
+   * Resolves entity reference layout revisions for a given field of a given entity.
+   *
+   * May optionally respect the entity bundles and language.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $field
+   *   The field of a given entity to get entity reference layout revisions for.
+   * @param string|null $language
+   *   Optional. Language to be respected for retrieved entities.
+   * @param array|null $bundles
+   *   Optional. List of bundles to be respected for retrieved entities.
+   * @param bool $access
+   *   Whether check for access or not. Default is true.
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
+   *   User entity to check access for. Default is null.
+   * @param string $accessOperation
+   *   Operation to check access for. Default is view.
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
+   *   The caching context related to the current field.
+   *
+   * @return \GraphQL\Deferred|null
+   *   A promise that will return entities or NULL if there aren't any.
+   */
+  public function resolve(EntityInterface $entity, string $field, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+    if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
+      return NULL;
+    }
+
+    $definition = $entity->getFieldDefinition($field);
+    if ($definition->getType() !== 'entity_reference_layout_revisioned') {
+      return NULL;
+    }
+
+    $definition = $entity->getFieldDefinition($field);
+    $type = $definition->getSetting('target_type');
+    if (($values = $entity->get($field)) && $values instanceof EntityReferenceFieldItemListInterface) {
+      $vids = array_map(function ($value) {
+        return $value['target_revision_id'];
+      }, $values->getValue());
+
+      $resolver = $this->entityRevisionBuffer->add($type, $vids);
+      return new Deferred(function () use ($type, $language, $bundles, $access, $accessUser, $accessOperation, $resolver, $context) {
+        $entities = $resolver() ?: [];
+
+        $entities = array_filter($entities, function (EntityInterface $entity) use ($language, $bundles, $access, $accessOperation, $accessUser, $context) {
+          if (isset($bundles) && !in_array($entity->bundle(), $bundles)) {
+            return FALSE;
+          }
+
+          // Get the correct translation.
+          if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+            $entity = $entity->getTranslation($language);
+            $entity->addCacheContexts(["static:language:{$language}"]);
+          }
+
+          // Check if the passed user (or current user if none is passed) has
+          // access to the entity, if not return NULL.
+          if ($access) {
+            /* @var $accessResult \Drupal\Core\Access\AccessResultInterface */
+            $accessResult = $entity->access($accessOperation, $accessUser, TRUE);
+            $context->addCacheableDependency($accessResult);
+            if (!$accessResult->isAllowed()) {
+              return FALSE;
+            }
+          }
+
+          return TRUE;
+        });
+
+        if (empty($entities)) {
+          $type = $this->entityTypeManager->getDefinition($type);
+          /** @var \Drupal\Core\Entity\EntityTypeInterface $type */
+          $tags = $type->getListCacheTags();
+          $context->addCacheTags($tags);
+          return NULL;
+        }
+
+        return $entities;
+      });
+    }
+
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
Based on #909, I added a similar plugin for entity reference layout revisions.
https://www.drupal.org/project/entity_reference_layout

This works for me to access the data from paragraph fields, what is still missing is exposing any layout information.

Because it took a me a while to figure out how to draft the schema, also sharing the code I am currently using for it. Maybe for later reference:

schema file

```
schema {
  query: Query
}

type Query {
  article(id: Int!): Article
  articles(
    offset: Int = 0
    limit: Int = 10
  ): ArticleConnection!
}

type Article {
  id: Int!
  title: String!
  author: String
  body: String
  contents: [ListItem]!
}

interface ListItem {
  id: Int!
}

type SectionItem implements ListItem {
  id: Int!
}

type ProductItem implements ListItem {
  id: Int!
  title: String!
  body: String
  product_reference_id: String
}

type TextItem implements ListItem {
  id: Int!
  text: String!
}

type ArticleConnection {
  total: Int!
  items: [Article!]
}
```

Schema class

```
  /**
   * {@inheritdoc}
   */
  public function getResolverRegistry() {
    $builder = new ResolverBuilder();
    $registry = new ResolverRegistry();

    $this->addQueryFields($registry, $builder);
    $this->addArticleFields($registry, $builder);

    // Re-usable connection type fields.
    $this->addConnectionFields('ArticleConnection', $registry, $builder);

    return $registry;
  }

  /**
   * @param \Drupal\graphql\GraphQL\ResolverRegistry $registry
   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
   */
  protected function addArticleFields(ResolverRegistry $registry, ResolverBuilder $builder) {
    $registry->addFieldResolver('Article', 'id',
      $builder->produce('entity_id')
        ->map('entity', $builder->fromParent())
    );

    $registry->addFieldResolver('Article', 'title',
      $builder->produce('entity_label')
        ->map('entity', $builder->fromParent())
    );

    $registry->addFieldResolver('Article', 'author',
      $builder->compose(
        $builder->produce('entity_owner')
          ->map('entity', $builder->fromParent()),
        $builder->produce('entity_label')
          ->map('entity', $builder->fromParent())
      )
    );

    $registry->addFieldResolver('Article', 'body',
      $builder->produce('property_path')
        ->map('type', $builder->fromValue('entity:node'))
        ->map('value', $builder->fromParent())
        ->map('path', $builder->fromValue('body.value'))
    );

    $registry->addFieldResolver('Article', 'contents',
      $builder->produce('entity_reference_layout_revisions')
        ->map('entity', $builder->fromParent())
        ->map('field', $builder->fromValue('field_contents'))
    );

    $registry->addTypeResolver('ListItem', function ($value) {
      if ($value instanceof Paragraph) {
        switch ($value->bundle()) {
          case 'section': return 'SectionItem';
          case 'product_item': return 'ProductItem';
          case 'text': return 'TextItem';
        }
      }
      throw new Error('Could not resolve ListItem type.');
    });
    
    // Helps traverse from paragraph over entity reference to the field values.
    $productItemBuilder = $builder->compose(
      $builder->produce('entity_reference')
        ->map('entity', $builder->fromParent())
        ->map('field', $builder->fromValue('field_product')),
      $builder->produce('seek')
        ->map('input', $builder->fromParent())
        ->map('position', $builder->fromValue(0))
    );

    $registry->addFieldResolver('ProductItem', 'id',
      $builder->compose(
        $productItemBuilder,
        $builder->produce('entity_id')
          ->map('entity', $builder->fromParent())
      )
    );

    $registry->addFieldResolver('ProductItem', 'title',
      $builder->compose(
        $productItemBuilder,
        $builder->produce('entity_label')
          ->map('entity', $builder->fromParent())
      )
    );

    $registry->addFieldResolver('ProductItem', 'body',
      $builder->compose(
        $productItemBuilder,
        $builder->produce('property_path')
          ->map('type', $builder->fromValue('entity:node'))
          ->map('value', $builder->fromParent())
          ->map('path', $builder->fromValue('body.value'))
      )
    );

    $registry->addFieldResolver('ProductItem', 'product_reference_id',
      $builder->compose(
        $productItemBuilder,
        $builder->produce('property_path')
          ->map('type', $builder->fromValue('entity:node'))
          ->map('value', $builder->fromParent())
          ->map('path', $builder->fromValue('field_product_reference_id.value'))
      )
    );

    $registry->addFieldResolver('TextItem', 'id',
      $builder->produce('entity_id')
        ->map('entity', $builder->fromParent())
    );

    $registry->addFieldResolver('TextItem', 'text',
      $builder->produce('property_path')
        ->map('type', $builder->fromValue('entity:paragraph'))
        ->map('value', $builder->fromParent())
        ->map('path', $builder->fromValue('field_text.value'))
    );
  }

  /**
   * @param \Drupal\graphql\GraphQL\ResolverRegistry $registry
   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
   */
  protected function addQueryFields(ResolverRegistry $registry, ResolverBuilder $builder) {
    $registry->addFieldResolver('Query', 'article',
      $builder->produce('entity_load')
        ->map('type', $builder->fromValue('node'))
        ->map('bundles', $builder->fromValue(['article']))
        ->map('id', $builder->fromArgument('id'))
    );

    $registry->addFieldResolver('Query', 'articles',
      $builder->produce('query_articles')
        ->map('offset', $builder->fromArgument('offset'))
        ->map('limit', $builder->fromArgument('limit'))
    );
  }

  /**
   * @param string $type
   * @param \Drupal\graphql\GraphQL\ResolverRegistry $registry
   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
   */
  protected function addConnectionFields($type, ResolverRegistry $registry, ResolverBuilder $builder) {
    $registry->addFieldResolver($type, 'total',
      $builder->callback(function (HeadlessConnection $connection) {
        return $connection->total();
      })
    );

    $registry->addFieldResolver($type, 'items',
      $builder->callback(function (HeadlessConnection $connection) {
        return $connection->items();
      })
    );
  }
```