### PR TITLE
Add get all field resolvers.

### DIFF
--- a/src/GraphQL/ResolverRegistry.php
+++ b/src/GraphQL/ResolverRegistry.php
@@ -110,6 +110,13 @@ class ResolverRegistry implements ResolverRegistryInterface {
   /**
    * {@inheritdoc}
    */
+  public function getAllFieldResolvers() {
+    return $this->fieldResolvers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addTypeResolver($abstract, callable $resolver) {
     $this->typeResolvers[$abstract] = $resolver;
     return $this;

--- a/src/GraphQL/ResolverRegistryInterface.php
+++ b/src/GraphQL/ResolverRegistryInterface.php
@@ -47,6 +47,11 @@ interface ResolverRegistryInterface {
   public function getFieldResolver($type, $field);
 
   /**
+   * @return callable
+   */
+  public function getAllFieldResolvers();
+
+  /**
    * TODO: Type resolvers should also get their own interface.
    *
    * @param string $abstract


### PR DESCRIPTION
Sometimes the front end team needs to add fields to the graphqls file.

However they do not know the name that the fields were dynamically mapped.

So I created this tab to show the list of fieldResolvers

But for that I need a method that returns all fieldResolvers.

![image](https://user-images.githubusercontent.com/6574942/75192398-e890b380-5732-11ea-94f9-39a596c76277.png)
