### PR TITLE
chore(travis): Drop Drupal 8.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
         - DRUPAL_CORE=8.8.x
         # Only run code coverage on the latest php and drupal versions.
         - WITH_PHPDBG_COVERAGE=true
+    # Tests on PHP 7.4 are broken right now, see
+    # https://github.com/drupal-graphql/graphql/issues/982
+    - php: 7.4
 
 mysql:
   database: graphql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
@@ -15,8 +16,8 @@ env:
     - SIMPLETEST_DB=mysql://root:@127.0.0.1/graphql
     - TRAVIS=true
   matrix:
-    - DRUPAL_CORE=8.7.x
     - DRUPAL_CORE=8.8.x
+    - DRUPAL_CORE=8.9.x
 
 matrix:
   # Don't wait for the allowed failures to build.
@@ -24,14 +25,14 @@ matrix:
   include:
     - php: 7.3
       env:
-        - DRUPAL_CORE=8.7.x
+        - DRUPAL_CORE=8.8.x
         # Only run code coverage on the latest php and drupal versions.
         - WITH_PHPDBG_COVERAGE=true
   allow_failures:
     # Allow the code coverage report to fail.
     - php: 7.3
       env:
-        - DRUPAL_CORE=8.7.x
+        - DRUPAL_CORE=8.8.x
         # Only run code coverage on the latest php and drupal versions.
         - WITH_PHPDBG_COVERAGE=true
 
@@ -85,18 +86,6 @@ install:
   # Bring in the module dependencies without requiring a merge plugin. The
   # require also triggers a full 'composer install'.
   - composer --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.12.5
-
-  # For Drupal 8.7 we have to manually upgrade zend-stdlib to avoid PHP 7.3
-  # incompatibilities.
-  - if [[ "$DRUPAL_CORE" = "8.7.x" ]];
-      then composer --working-dir=$DRUPAL_BUILD_DIR require zendframework/zend-stdlib:3.2.1;
-    fi
-
-  # For Drupal 8.7 we have to manually upgrade phpunit to avoid PHP 7.3
-  # incompatibilities.
-  - if [[ "$DRUPAL_CORE" = "8.7.x" ]];
-      then composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade;
-    fi
 
 script:
   # Run the unit tests using phpdbg if the environment variable is 'true'.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ install:
   # Bring in the module dependencies without requiring a merge plugin. The
   # require also triggers a full 'composer install'.
   - composer --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.12.5
+  - composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade
 
 script:
   # Run the unit tests using phpdbg if the environment variable is 'true'.


### PR DESCRIPTION
Fix Travis fails, we don't care about Drupal 8.7 anymore.