### PR TITLE
fix(Travis CI): Prevent composer download fails 'Could not authenticate against github.com'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
   # Bring in the module dependencies without requiring a merge plugin. The
   # require also triggers a full 'composer install'.
   - composer --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.13.1 drupal/typed_data:^1.0
-  - composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade
+  - composer --working-dir=$DRUPAL_BUILD_DIR update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies
 
 script:
   # Run the unit tests using phpdbg if the environment variable is 'true'.

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,13 +82,13 @@ install:
       then grep -rl 'cli' $DRUPAL_BUILD_DIR/core $DRUPAL_BUILD_DIR/modules | xargs sed -i "s/'cli'/'phpdbg'/g" || true;
     fi
 
-  # We don't care about any dirty changes in teh vendor directory, throw them
+  # We don't care about any dirty changes in the vendor directory, throw them
   # all away.
   - composer --working-dir=$DRUPAL_BUILD_DIR config discard-changes true
   # Bring in the module dependencies without requiring a merge plugin. The
   # require also triggers a full 'composer install'.
   - composer --no-interaction --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.13.1 drupal/typed_data:^1.0
-  - composer --no-interaction --working-dir=$DRUPAL_BUILD_DIR update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies
+  - composer --no-interaction --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade
 
 script:
   # Run the unit tests using phpdbg if the environment variable is 'true'.

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,13 @@ install:
       then grep -rl 'cli' $DRUPAL_BUILD_DIR/core $DRUPAL_BUILD_DIR/modules | xargs sed -i "s/'cli'/'phpdbg'/g" || true;
     fi
 
+  # We don't care about any dirty changes in teh vendor directory, throw them
+  # all away.
+  - composer --working-dir=$DRUPAL_BUILD_DIR config discard-changes true
   # Bring in the module dependencies without requiring a merge plugin. The
   # require also triggers a full 'composer install'.
-  - composer --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.13.1 drupal/typed_data:^1.0
-  - composer --working-dir=$DRUPAL_BUILD_DIR update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies
+  - composer --no-interaction --working-dir=$DRUPAL_BUILD_DIR require webonyx/graphql-php:^0.13.1 drupal/typed_data:^1.0
+  - composer --no-interaction --working-dir=$DRUPAL_BUILD_DIR update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies
 
 script:
   # Run the unit tests using phpdbg if the environment variable is 'true'.


### PR DESCRIPTION
Errors in Travis CI:
```
$  composer --working-dir=$DRUPAL_BUILD_DIR run-script drupal-phpunit-upgrade
> Drupal\Composer\Composer::ensureComposerVersion
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 21 updates, 1 removal

  - Removing phpunit/phpunit-mock-objects (5.0.10)
  - Updating sebastian/resource-operations (1.0.0 => 2.0.1): Downloading

  [Composer\Downloader\TransportException]   
  Could not authenticate against github.com  
```