### PR TITLE
fix(Travis CI): Prevent composer cache fails by restricting the directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ mysql:
 # Cache composer downloads.
 cache:
   directories:
-    - $HOME/.composer
+    - $HOME/.composer/cache
 
 before_install:
   # Disable xdebug. It might not exist on PHP 7.4 so ignore that error.


### PR DESCRIPTION
Still seeing composer caching problems: https://travis-ci.org/github/drupal-graphql/graphql/builds/668927737