### PR TITLE
In TaxonomyLoadTree.php producer do not return term if there is no translation to provided language.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
+++ b/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
@@ -175,8 +175,14 @@ class TaxonomyLoadTree extends DataProducerPluginBase implements ContainerFactor
         $context->addCacheableDependency($entities[$id]);
 
         if (isset($language) && $language !== $entities[$id]->language()->getId() && $entities[$id] instanceof TranslatableInterface) {
-          $entities[$id] = $entities[$id]->getTranslation($language);
-          $entities[$id]->addCacheContexts(["static:language:{$language}"]);
+          if ($entities[$id]->hasTranslation($language)) {
+            $entities[$id] = $entities[$id]->getTranslation($language);
+            $entities[$id]->addCacheContexts(["static:language:{$language}"]);
+          }
+          else {
+            unset($entities[$id]);
+            continue;
+          }
         }
 
         if ($access) {


### PR DESCRIPTION
There are 2 issues this PR resolves:
1. E.g. there are 2 languages on site: `en` and `fr`. Taxonomy term has only `en` translation. If you provide `language` argument `fr` you will get error message `Invalid translation language (fr) specified.`
2. Data producer returns taxonomy term even if there is no translation to language provided with `language` argument.