### PR TITLE
Updating for D9 Compatibility

### DIFF
--- a/graphql.info.yml
+++ b/graphql.info.yml
@@ -4,5 +4,6 @@ description: 'Base module for integrating GraphQL with Drupal.'
 package: GraphQL
 configure: graphql.config_page
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - typed_data:typed_data

--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields.php
@@ -3,6 +3,7 @@
 namespace Drupal\graphql\Plugin\GraphQL\DataProducer\EntityDefinition;
 
 use Drupal\Core\Entity\ContentEntityType;
+use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -48,6 +49,13 @@ class Fields extends DataProducerPluginBase implements ContainerFactoryPluginInt
   protected $entityTypeManager;
 
   /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManager
+   */
+  protected $entityFieldManager;
+
+  /**
    * {@inheritdoc}
    *
    * @codeCoverageIgnore
@@ -57,7 +65,8 @@ class Fields extends DataProducerPluginBase implements ContainerFactoryPluginInt
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager')
     );
   }
 
@@ -73,16 +82,21 @@ class Fields extends DataProducerPluginBase implements ContainerFactoryPluginInt
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager service.
    *
+   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   *   The entity field manager service.
+   *
    * @codeCoverageIgnore
    */
   public function __construct(
     array $configuration,
     string $plugin_id,
     array $plugin_definition,
-    EntityTypeManager $entity_type_manager
+    EntityTypeManager $entity_type_manager,
+    EntityFieldManager $entity_field_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
   }
 
   /**
@@ -115,12 +129,12 @@ class Fields extends DataProducerPluginBase implements ContainerFactoryPluginInt
         $key = $bundle_context['key'];
         $id = $entity_definition->id();
         $entity_id = $id . '.' . $id . '.' . $key;
-        $fields = \Drupal::entityManager()->getFieldDefinitions($id, $key);
+        $fields = $this->entityFieldManager->getFieldDefinitions($id, $key);
       }
       else {
         $id = $entity_definition->id();
         $entity_id = $id . '.' . $id . '.default';
-        $fields = \Drupal::entityManager()->getFieldDefinitions($id, $id);
+        $fields = $this->entityFieldManager->getFieldDefinitions($id, $id);
       }
 
       /** @var \Drupal\Core\Config\Entity\ConfigEntityStorage $form_display_context */

--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields.php
@@ -81,7 +81,6 @@ class Fields extends DataProducerPluginBase implements ContainerFactoryPluginInt
    *   The plugin definition array.
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager service.
-   *
    * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
    *   The entity field manager service.
    *

--- a/tests/src/Kernel/Framework/UploadMutationTest.php
+++ b/tests/src/Kernel/Framework/UploadMutationTest.php
@@ -20,7 +20,7 @@ class UploadMutationTest extends GraphQLTestBase {
       schema {
         mutation: Mutation
       }
-  
+
       type Mutation {
         store(file: Upload!): String
       }
@@ -31,7 +31,7 @@ GQL;
     $this->setUpSchema($schema);
 
     // Create dummy file, since symfony will test if it exists..
-    $file = file_directory_temp() . '/graphql_upload_test.txt';
+    $file = \Drupal::service('file_system')->getTempDirectory() . '/graphql_upload_test.txt';
     touch($file);
 
     // Mock a mutation that accepts the upload input and just returns


### PR DESCRIPTION
This addresses issues identified with the Upgrade Status module specifically for the 8.x-4.x branch. Though if wanted I could run this against the 8.x-3.x branch as well.

In `/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields.php` on lines 118 and 123:

> Call to deprecated method entityManager() of class Drupal. Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use \Drupal::entityTypeManager() instead in most cases. If the needed method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the deprecated \Drupal\Core\Entity\EntityManager to find the correct interface or service.

In `/tests/src/Kernel/Framework/UploadMutationTest.php` on line 34:

> Call to deprecated function file_directory_temp(). Deprecated in drupal:8.8.0 and is removed from drupal:9.0.0. Use \Drupal\Core\File\FileSystemInterface::getTempDirectory() instead.

And adding the `core_version_requirement` to the .info.yml file.

I've tested this locally with Drupal 8.8.4 and all seems to work as expected.