### PR TITLE
Examples module doesn't throw error when limit is greater than MAX_LIMIT

### DIFF
--- a/examples/src/Plugin/GraphQL/DataProducer/QueryArticles.php
+++ b/examples/src/Plugin/GraphQL/DataProducer/QueryArticles.php
@@ -87,7 +87,7 @@ class QueryArticles extends DataProducerPluginBase implements ContainerFactoryPl
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function resolve($offset, $limit, RefinableCacheableDependencyInterface $metadata) {
-    if (!$limit > static::MAX_LIMIT) {
+    if ($limit > static::MAX_LIMIT) {
       throw new UserError(sprintf('Exceeded maximum query limit: %s.', static::MAX_LIMIT));
     }
 


### PR DESCRIPTION
PR for issue [1007](https://github.com/drupal-graphql/graphql/issues/1007)