### PR TITLE
Fix InvalidPluginDefinitionException calls

### DIFF
--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -225,7 +225,14 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
     $file = "{$module->getPath()}/graphql/{$id}.graphqls";
 
     if (!file_exists($file)) {
-      throw new InvalidPluginDefinitionException(sprintf("Missing schema definition file at %s.", $file));
+      throw new InvalidPluginDefinitionException(
+        $id,
+        t('The module "@name" needs to have a schema definition "@file" in its folder for "@plugin" to be valid.', [
+          '@name' => \Drupal::moduleHandler()->getName($module->getName()),
+          '@file' => "graphql/{$id}.graphqls",
+          '@plugin' => $definition['class'],
+        ])
+      );
     }
 
     return file_get_contents($file) ?: NULL;

--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -230,7 +230,7 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
         $id,
         sprintf(
           'The module "%s" needs to have a schema definition "%s" in its folder for "%s" to be valid.',
-          \Drupal::moduleHandler()->getName($module->getName()), $path, $definition['class']));
+          $module->getName(), $path, $definition['class']));
     }
 
     return file_get_contents($file) ?: NULL;

--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -222,17 +222,15 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
     $id = $this->getPluginId();
     $definition = $this->getPluginDefinition();
     $module = $this->moduleHandler->getModule($definition['provider']);
-    $file = "{$module->getPath()}/graphql/{$id}.graphqls";
+    $path = 'graphql/' . $id . '.graphqls';
+    $file = $module->getPath() . '/' . $path;
 
     if (!file_exists($file)) {
       throw new InvalidPluginDefinitionException(
         $id,
-        t('The module "@name" needs to have a schema definition "@file" in its folder for "@plugin" to be valid.', [
-          '@name' => \Drupal::moduleHandler()->getName($module->getName()),
-          '@file' => "graphql/{$id}.graphqls",
-          '@plugin' => $definition['class'],
-        ])
-      );
+        sprintf(
+          'The module "%s" needs to have a schema definition "%s" in its folder for "%s" to be valid.',
+          \Drupal::moduleHandler()->getName($module->getName()), $path, $definition['class']));
     }
 
     return file_get_contents($file) ?: NULL;

--- a/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
+++ b/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
@@ -92,7 +92,14 @@ abstract class SdlSchemaExtensionPluginBase extends PluginBase implements Schema
     $file = "{$module->getPath()}/graphql/{$id}.{$type}.graphqls";
 
     if (!file_exists($file)) {
-      throw new InvalidPluginDefinitionException(sprintf("Missing schema definition file at %s.", $file));
+      throw new InvalidPluginDefinitionException(
+        $id,
+        t('The module "@name" needs to have a schema definition "@file" in its folder for "@plugin" to be valid.', [
+          '@name' => \Drupal::moduleHandler()->getName($module->getName()),
+          '@file' => "graphql/{$id}.{$type}.graphqls",
+          '@plugin' => $definition['class'],
+        ])
+      );
     }
 
     return file_get_contents($file) ?: NULL;

--- a/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
+++ b/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
@@ -89,17 +89,14 @@ abstract class SdlSchemaExtensionPluginBase extends PluginBase implements Schema
     $id = $this->getPluginId();
     $definition = $this->getPluginDefinition();
     $module = $this->moduleHandler->getModule($definition['provider']);
-    $file = "{$module->getPath()}/graphql/{$id}.{$type}.graphqls";
+    $path = 'graphql/' . $id . '.' . $type . '.graphqls';
+    $file = $module->getPath() . '/' . $path;
 
     if (!file_exists($file)) {
       throw new InvalidPluginDefinitionException(
         $id,
-        t('The module "@name" needs to have a schema definition "@file" in its folder for "@plugin" to be valid.', [
-          '@name' => \Drupal::moduleHandler()->getName($module->getName()),
-          '@file' => "graphql/{$id}.{$type}.graphqls",
-          '@plugin' => $definition['class'],
-        ])
-      );
+        sprintf('The module "%s" needs to have a schema definition "%s" in its folder for "%s" to be valid.',
+          \Drupal::moduleHandler()->getName($module->getName()), $path, $definition['class']));
     }
 
     return file_get_contents($file) ?: NULL;

--- a/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
+++ b/src/Plugin/GraphQL/SchemaExtension/SdlSchemaExtensionPluginBase.php
@@ -96,7 +96,7 @@ abstract class SdlSchemaExtensionPluginBase extends PluginBase implements Schema
       throw new InvalidPluginDefinitionException(
         $id,
         sprintf('The module "%s" needs to have a schema definition "%s" in its folder for "%s" to be valid.',
-          \Drupal::moduleHandler()->getName($module->getName()), $path, $definition['class']));
+          $module->getName(), $path, $definition['class']));
     }
 
     return file_get_contents($file) ?: NULL;


### PR DESCRIPTION
The [InvalidPluginDefinitionException](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Plugin%21Exception%21InvalidPluginDefinitionException.php/class/InvalidPluginDefinitionException/8.2.x) has a constructor signature like this:
```php
public function __construct(
  $plugin_id, $message = '', $code = 0, \Exception $previous = NULL);
```

But the current exception calls are like this:
```php
$file = "{$module->getPath()}/graphql/{$id}.{$type}.graphqls";

if (!file_exists($file)) {
  throw new InvalidPluginDefinitionException(
    sprintf("Missing schema definition file at %s.", $file));
}
```

Which has 2 problem:
1. The exception generated has no `$message` and is frustrating to debug with.
2. Even if the message is in the right place, the message text can be improved to give a better developer experience.

This PR does 2 things:
* The call to the InvalidPluginDefinitionException doesn't match
  the expected paramters. The first parameter should be plugin id
  and the second paramter should be the message.
* Improved the message text to better describe the situation for
  module developer to fix their module.to