### PR TITLE
Fix results cache shared between different schemas

### DIFF
--- a/src/GraphQL/Execution/FieldContext.php
+++ b/src/GraphQL/Execution/FieldContext.php
@@ -26,7 +26,7 @@ class FieldContext implements RefinableCacheableDependencyInterface {
    * @param \GraphQL\Type\Definition\ResolveInfo $info
    */
   public function __construct(ResolveContext $context, ResolveInfo $info) {
-    $this->addCacheContexts(['user.permissions']);
+    $this->addCacheContexts(['user.permissions', 'url.path']);
     $this->context = $context;
     $this->info = $info;
   }

--- a/src/GraphQL/Execution/ResolveContext.php
+++ b/src/GraphQL/Execution/ResolveContext.php
@@ -63,7 +63,7 @@ class ResolveContext implements RefinableCacheableDependencyInterface {
     $type,
     array $config
   ) {
-    $this->addCacheContexts(['user.permissions']);
+    $this->addCacheContexts(['user.permissions', 'url.path']);
 
     $this->server = $server;
     $this->config = $config;

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -113,7 +113,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
    * {@inheritdoc}
    */
   protected function defaultCacheContexts() {
-    return ['user.permissions'];
+    return ['user.permissions', 'url.path'];
   }
 
   /**


### PR DESCRIPTION
We came across this when using a standalone GraphiQL (not the one in Drupal admin). The introspection query gets cached for the first hit schema and then is returned for all other endpoints/schemas (because the query is exactly the same, admittedly a very unlikely scenario for anything but introspection).

I have assumed that the results should be cached per schema in all cases so I've added the url.path context (as you require different schemas/servers to be on different urls). I don't fully understand the context bubbling so this may not be the best place(s) to do it but here is the patch we have used successfully to solve it for us.

[add_url_path_context.patch.txt](https://github.com/drupal-graphql/graphql/files/4694671/add_url_path_context.patch.txt)