### PR TITLE
Fix crash on no translation in entity_translation producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
@@ -97,7 +97,7 @@ class EntityTranslation extends DataProducerPluginBase implements ContainerFacto
    * @return |null
    */
   public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation) {
-    if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
+    if ($entity instanceof TranslatableInterface && $entity->isTranslatable() && $entity->hasTranslation($language)) {
       $entity = $entity->getTranslation($language);
       $entity->addCacheContexts(["static:language:{$language}"]);
       // Check if the passed user (or current user if none is passed) has access


### PR DESCRIPTION
Fixes bug when `entity_translation` data producer tries to get entity's translation without checking if translation exists.