### PR TITLE
Fix crash on no translation in entity_load producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -161,8 +161,13 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
 
       // Get the correct translation.
       if (isset($language) && $language !== $entity->language()->getId() && $entity instanceof TranslatableInterface) {
-        $entity = $entity->getTranslation($language);
-        $entity->addCacheContexts(["static:language:{$language}"]);
+        if ($entity->hasTranslation($language)) {
+          $entity = $entity->getTranslation($language);
+          $entity->addCacheContexts(["static:language:{$language}"]);
+        }
+        else {
+          return NULL;
+        }
       }
 
       // Check if the passed user (or current user if none is passed) has access


### PR DESCRIPTION
Fixes bug when `entity_load` data producer tries to get entity's translation without checking if translation exists.