### PR TITLE
Support all default field types for Entity Definitions Default Value resolver

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/DefaultValue.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/DefaultValue.php
@@ -40,7 +40,7 @@ class DefaultValue extends DataProducerPluginBase {
       switch ($entity_definition_field->getType()) {
         case 'list_integer':
         case 'list_string':
-	case 'text_long':
+        case 'text_long':
           return $default_value ? $default_value[0]['value'] : NULL;
 
         case 'boolean':

--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/DefaultValue.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/DefaultValue.php
@@ -39,7 +39,8 @@ class DefaultValue extends DataProducerPluginBase {
     if (is_array($default_value)) {
       switch ($entity_definition_field->getType()) {
         case 'list_integer':
-        case 'text_long':
+        case 'list_string':
+	case 'text_long':
           return $default_value ? $default_value[0]['value'] : NULL;
 
         case 'boolean':


### PR DESCRIPTION
Currently only couple of field types are resolved by `DefaultValue` data producer (from `EntityDefinitions` collection). This PR is a placeholder to support them all. Starting by the ones we use across the development.