### PR TITLE
Fix composable GraphQL schema example not working

### DIFF
--- a/examples/graphql_composable/graphql/composable_extension.base.graphqls
+++ b/examples/graphql_composable/graphql/composable_extension.base.graphqls
@@ -1,7 +1,3 @@
-type schema {
-  mutation: Mutation
-}
-
 type Mutation
 
 scalar Violation

--- a/examples/graphql_composable/src/GraphQL/Response/ArticleResponse.php
+++ b/examples/graphql_composable/src/GraphQL/Response/ArticleResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\graphql_composable\Wrappers\Response;
+namespace Drupal\graphql_composable\GraphQL\Response;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\graphql\GraphQL\Response\Response;

--- a/examples/graphql_composable/src/Plugin/GraphQL/DataProducer/CreateArticle.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/DataProducer/CreateArticle.php
@@ -5,9 +5,9 @@ namespace Drupal\graphql_composable\Plugin\GraphQL\DataProducer;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\graphql_composable\GraphQL\Response\ArticleResponse;
 use Drupal\node\Entity\Node;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\graphql_composable\Wrappers\Response\ArticleResponse;
 
 /**
  * Creates a new article entity.
@@ -70,7 +70,7 @@ class CreateArticle extends DataProducerPluginBase implements ContainerFactoryPl
    * @param array $data
    *   The title of the job.
    *
-   * @return \Drupal\graphql_composable\Wrappers\Response\ArticleResponse
+   * @return \Drupal\graphql_composable\GraphQL\Response\ArticleResponse
    *   The newly created article.
    *
    * @throws \Exception

--- a/examples/graphql_composable/src/Plugin/GraphQL/DataProducer/CreateArticle.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/DataProducer/CreateArticle.php
@@ -86,7 +86,8 @@ class CreateArticle extends DataProducerPluginBase implements ContainerFactoryPl
       $node = Node::create($values);
       $node->save();
       $response->setArticle($node);
-    }else {
+    }
+    else {
       $response->addViolation(
         $this->t('You do not have permissions to create articles.')
       );

--- a/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
@@ -2,11 +2,7 @@
 
 namespace Drupal\graphql_composable\Plugin\GraphQL\Schema;
 
-use Drupal\graphql\GraphQL\Execution\ResolveContext;
-use Drupal\graphql\GraphQL\ResolverRegistry;
-use Drupal\graphql\GraphQL\Response\ResponseInterface;
 use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
-use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @Schema(
@@ -17,52 +13,4 @@ use GraphQL\Type\Definition\ResolveInfo;
  */
 class ComposableSchemaExample extends ComposableSchema {
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getResolverRegistry() {
-    // Initialize registry which will register all the field and type resolvers
-    // we'd need. Initialize it with default field resolver which is used as
-    // a fallback option to resolve the generic fields or fields following
-    // some specific rules. Can be initialized also with default type resolver
-    // (second argument to ResolverRegistry constructor).
-    $registry = new ResolverRegistry([
-      __CLASS__,
-      'defaultFieldResolver',
-    ]);
-
-    return $registry;
-  }
-
-  /**
-   * The default field resolver.
-   *
-   * Used if no field resolver was explicitly registered.
-   *
-   * @param array|\ArrayAccess|object $source
-   *   The source (parent) value.
-   * @param array $args
-   *   An array of arguments.
-   * @param \Drupal\graphql\GraphQL\Execution\ResolveContext $context
-   *   The context object.
-   * @param \GraphQL\Type\Definition\ResolveInfo $info
-   *   The resolve info object.
-   *
-   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface|\Closure|array
-   *   The result for the field.
-   */
-  public static function defaultFieldResolver($source, array $args, ResolveContext $context, ResolveInfo $info) {
-    $field_name = $info->fieldName;
-    $property = NULL;
-
-    if ($source instanceof ResponseInterface) {
-      // Resolves violations which are defined under "error" key in the example
-      // schema.
-      if ($field_name == 'errors') {
-        return $source->getViolations();
-      }
-    }
-
-    return $property;
-  }
 }

--- a/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
@@ -14,6 +14,24 @@ use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
  * )
  */
 class ComposableSchemaExample extends ComposableSchema {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResolverRegistry() {
+    // Initialize registry which will register all the field and type resolvers
+    // we'd need. Initialize it with default field resolver which is used as
+    // a fallback option to resolve the generic fields or fields following
+    // some specific rules. Can be initialized also with default type resolver
+    // (second argument to ResolverRegistry constructor).
+    $registry = new ResolverRegistry([
+      __CLASS__,
+      'defaultFieldResolver',
+    ]);
+
+    return $registry;
+  }
+
   /**
    * The default field resolver.
    *

--- a/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
@@ -61,16 +61,6 @@ class ComposableSchemaExample extends ComposableSchema {
       if ($field_name == 'errors') {
         return $source->getViolations();
       }
-
-      // Allow automatic resolving of fields on Response objects with the same
-      // name as the method on that Response object. For example, this will
-      // automatically resolve "article" field as there is a method on
-      // ArticleResponse object "ArticleResponse::article()" which returns
-      // article node.
-      if (is_callable([$source, $field_name])) {
-        $property = [$source, $field_name];
-        return $property($source, $args, $context, $info);
-      }
     }
 
     return $property;

--- a/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/Schema/ComposableSchemaExample.php
@@ -2,9 +2,10 @@
 
 namespace Drupal\graphql_composable\Plugin\GraphQL\Schema;
 
-use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\GraphQL\ResolverRegistry;
 use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @Schema(

--- a/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
@@ -6,7 +6,7 @@ use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistryInterface;
 use Drupal\graphql\GraphQL\Response\ResponseInterface;
 use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
-use Drupal\graphql_composable\Wrappers\Response\ArticleResponse;
+use Drupal\graphql_composable\GraphQL\Response\ArticleResponse;
 
 /**
  * @SchemaExtension(

--- a/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
@@ -43,6 +43,12 @@ class ComposableSchemaExampleExtension extends SdlSchemaExtensionPluginBase {
       }),
     );
 
+    $registry->addFieldResolver('ArticleResponse', 'errors',
+      $builder->callback(function (ArticleResponse $response) {
+        return $response->getViolations();
+      }),
+    );
+
     $registry->addFieldResolver('Article', 'id',
       $builder->produce('entity_id')
         ->map('entity', $builder->fromParent())

--- a/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
@@ -37,6 +37,12 @@ class ComposableSchemaExampleExtension extends SdlSchemaExtensionPluginBase {
         ->map('data', $builder->fromArgument('data'))
     );
 
+    $registry->addFieldResolver('ArticleResponse', 'article',
+      $builder->callback(function (ArticleResponse $response) {
+        return $response->article();
+      }),
+    );
+
     $registry->addFieldResolver('Article', 'id',
       $builder->produce('entity_id')
         ->map('entity', $builder->fromParent())

--- a/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
+++ b/examples/graphql_composable/src/Plugin/GraphQL/SchemaExtension/ComposableSchemaExampleExtension.php
@@ -59,7 +59,7 @@ class ComposableSchemaExampleExtension extends SdlSchemaExtensionPluginBase {
     );
 
     // Response type resolver.
-    $registry->addTypeResolver('ResponseInterface', [
+    $registry->addTypeResolver('Response', [
       __CLASS__,
       'resolveResponse',
     ]);

--- a/examples/graphql_composable/src/Wrappers/Response/ArticleResponse.php
+++ b/examples/graphql_composable/src/Wrappers/Response/ArticleResponse.php
@@ -1,7 +1,4 @@
-
 <?php
-
-declare(strict_types = 1);
 
 namespace Drupal\graphql_composable\Wrappers\Response;
 

--- a/src/GraphQL/Response/Response.php
+++ b/src/GraphQL/Response/Response.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\graphql\GraphQL\Response;
 
-use Drupal\jobiqo_graphql\Wrappers\Violation\ViolationCollection;
-
 /**
  * Base class for responses containing the violations.
  */


### PR DESCRIPTION
@joaogarin fixed the schema to make it work, example of mutation and its response.
Mutation:
```
mutation {
  createArticle(data: {
    title: "test title"
  }) {
    article {
      id
      title
      author
    }
  }
}
```

Response:
```
{
  "data": {
    "createArticle": {
      "article": {
        "id": 6,
        "title": "test title",
        "author": "admin"
      }
    }
  }
}
```