### PR TITLE
Add 'core_version_requirement: ^8 || ^9' 

### DIFF
--- a/examples/graphql_examples.info.yml
+++ b/examples/graphql_examples.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Examples for the GraphQL module.'
 package: GraphQL
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - graphql:graphql
   - node:node


### PR DESCRIPTION
The "GraphQL Examples" module cannot be enabled in Drupal 9 without adding the 'core_version_requirement:' stanza in graphql_examples.info.yml