### PR TITLE
Remediation for deprecations in Symfony 4.3 and in PHPUnit.

### DIFF
--- a/src/Event/OperationEvent.php
+++ b/src/Event/OperationEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\graphql\Event;
 
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use GraphQL\Executor\ExecutionResult;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class OperationEvent extends Event {
 

--- a/src/EventSubscriber/SubrequestSubscriber.php
+++ b/src/EventSubscriber/SubrequestSubscriber.php
@@ -8,7 +8,7 @@ use Drupal\Core\StringTranslation\Translator\TranslatorInterface;
 use Drupal\language\LanguageNegotiatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class SubrequestSubscriber implements EventSubscriberInterface {
@@ -36,7 +36,7 @@ class SubrequestSubscriber implements EventSubscriberInterface {
    * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
    *   The kernel event object.
    */
-  public function onKernelRequest(GetResponseEvent $event) {
+  public function onKernelRequest(RequestEvent $event) {
     $request = $event->getRequest();
     if (!$request->attributes->has('_graphql_subrequest')) {
       return;

--- a/tests/src/Kernel/Framework/BufferedFieldTest.php
+++ b/tests/src/Kernel/Framework/BufferedFieldTest.php
@@ -44,7 +44,7 @@ GQL;
    */
   public function testBatchedFields() {
     $buffer = $this->getMockBuilder(BufferBase::class)
-      ->setMethods(['resolveBufferArray'])
+      ->onlyMethods(['resolveBufferArray'])
       ->getMock();
 
     $users = [

--- a/tests/src/Kernel/Framework/DisabledResultCacheTest.php
+++ b/tests/src/Kernel/Framework/DisabledResultCacheTest.php
@@ -49,7 +49,7 @@ GQL;
 
     $object = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $object->expects($this->exactly(2))

--- a/tests/src/Kernel/Framework/ResultCacheTest.php
+++ b/tests/src/Kernel/Framework/ResultCacheTest.php
@@ -41,7 +41,7 @@ GQL;
   public function testCacheableResult() {
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->once())
@@ -66,7 +66,7 @@ GQL;
    */
   public function testUncacheableResult() {
     $cacheable = $this->getMockBuilder(CacheableDependencyInterface::class)
-      ->setMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
+      ->onlyMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
       ->getMock();
 
     $cacheable->expects($this->any())
@@ -83,7 +83,7 @@ GQL;
 
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->exactly(2))
@@ -111,7 +111,7 @@ GQL;
    */
   public function testUncacheableResultAnnotation() {
     $cacheable = $this->getMockBuilder(CacheableDependencyInterface::class)
-      ->setMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
+      ->onlyMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
       ->getMock();
 
     $cacheable->expects($this->any())
@@ -128,7 +128,7 @@ GQL;
 
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->exactly(2))
@@ -157,7 +157,7 @@ GQL;
   public function testVariables() {
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->exactly(2))
@@ -185,7 +185,7 @@ GQL;
    */
   public function testContext() {
     $cacheable = $this->getMockBuilder(CacheableDependencyInterface::class)
-      ->setMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
+      ->onlyMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
       ->getMock();
 
     $cacheable->expects($this->any())
@@ -202,7 +202,7 @@ GQL;
 
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->exactly(2))
@@ -261,7 +261,7 @@ GQL;
    */
   public function testTags() {
     $cacheable = $this->getMockBuilder(CacheableDependencyInterface::class)
-      ->setMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
+      ->onlyMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
       ->getMock();
 
     $cacheable->expects($this->any())
@@ -278,7 +278,7 @@ GQL;
 
     $dummy = $this->getMockBuilder(Server::class)
       ->disableOriginalConstructor()
-      ->setMethods(['id'])
+      ->onlyMethods(['id'])
       ->getMock();
 
     $dummy->expects($this->exactly(2))

--- a/tests/src/Kernel/Framework/TestFrameworkTest.php
+++ b/tests/src/Kernel/Framework/TestFrameworkTest.php
@@ -26,7 +26,7 @@ GQL;
     $this->setUpSchema($schema);
 
     $cacheable = $this->getMockBuilder(CacheableDependencyInterface::class)
-      ->setMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
+      ->onlyMethods(['getCacheTags', 'getCacheMaxAge', 'getCacheContexts'])
       ->getMock();
 
     $cacheable->expects($this->any())


### PR DESCRIPTION
setMethods() has been deprecated in PHPUnit in favor of using onlyMethods();

Symfony 4.3 had these deprecations:
 
   ../Component/EventDispatcher/Event was moved to ../Contracts ...

and

  ../Component/HttpKernel/Event/GetResponseEvent was renamed as ../RequestEvent