### PR TITLE
InlineComment, VariableComment and NewlineAfterCloseBrace Rules removed

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,14 +47,6 @@
     <exclude name="Drupal.Commenting.FunctionComment.ReturnCommentIndentation"/>
     <exclude name="Drupal.Commenting.FunctionComment.ReturnTypeSpaces"/>
     <exclude name="Drupal.Commenting.FunctionComment.TypeHintMissing"/>
-    <exclude name="Drupal.Commenting.InlineComment.InvalidEndChar"/>
-    <exclude name="Drupal.Commenting.InlineComment.NoSpaceBefore"/>
-    <exclude name="Drupal.Commenting.InlineComment.SpacingAfter"/>
-    <exclude name="Drupal.Commenting.InlineComment.SpacingBefore"/>
-    <exclude name="Drupal.Commenting.InlineComment.SpacingBefore"/>
-    <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
-    <exclude name="Drupal.Commenting.VariableComment.Missing"/>
-    <exclude name="Drupal.ControlStructures.ControlSignature.NewlineAfterCloseBrace"/>
   </rule>
 
 </ruleset>

--- a/src/Entity/Server.php
+++ b/src/Entity/Server.php
@@ -98,21 +98,21 @@ class Server extends ConfigEntityBase implements ServerInterface {
   /**
    * Whether the server is in debug mode.
    *
-   * @var boolean
+   * @var bool
    */
   public $debug = FALSE;
 
   /**
    * Whether the server should cache its results.
    *
-   * @var boolean
+   * @var bool
    */
   public $caching = TRUE;
 
   /**
    * Whether the server allows query batching.
    *
-   * @var boolean
+   * @var bool
    */
   public $batching = TRUE;
 

--- a/src/Form/PersistedQueriesForm.php
+++ b/src/Form/PersistedQueriesForm.php
@@ -13,6 +13,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PersistedQueriesForm extends EntityForm {
 
+  /**
+   * @var PersistedQueryPluginManager
+   */
   protected $persistedQueryPluginManager;
 
   /**
@@ -76,7 +79,7 @@ class PersistedQueriesForm extends EntityForm {
       ];
     }
 
-    // Set the weights of the persisted query plugins
+    // Set the weights of the persisted query plugins.
     $form['weights'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Order'),

--- a/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
@@ -64,7 +64,7 @@ class DataProducerProxy implements ResolverInterface {
   protected $mapping = [];
 
   /**
-   * @var boolean
+   * @var bool
    */
   protected $cached = FALSE;
 

--- a/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkAttribute.php
+++ b/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkAttribute.php
@@ -41,7 +41,8 @@ class MenuLinkAttribute extends DataProducerPluginBase {
     $attributeValue = NestedArray::getValue($options, ['attributes', $attribute]);
     if (is_array($attributeValue)) {
       return implode(" ", $attributeValue);
-    } else {
+    }
+    else {
       return $attributeValue;
     }
   }

--- a/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageDerivativeTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageDerivativeTest.php
@@ -77,10 +77,9 @@ class ImageDerivativeTest extends GraphQLTestBase {
     );
 
     // TODO: Add cache checks.
-    //    $this->assertContains('config:image.style.test_style',
-    //    $metadata->getCacheTags());
-    //    $this->assertContains('test_tag', $metadata->getCacheTags());
-
+    // $this->assertContains('config:image.style.test_style',
+    // $metadata->getCacheTags());
+    // $this->assertContains('test_tag', $metadata->getCacheTags());
     // Test that we don't get the derivative if we don't have access to the
     // original file, but we still get the access result cache tags.
     $result = $this->executeDataProducer('image_derivative', [
@@ -91,8 +90,8 @@ class ImageDerivativeTest extends GraphQLTestBase {
     $this->assertNull($result);
 
     // TODO: Add cache checks.
-    //    $this->assertContains('test_tag_forbidden',
-    //    $metadata->getCacheTags());
+    // $this->assertContains('test_tag_forbidden',
+    // $metadata->getCacheTags());
   }
 
 }

--- a/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageUrlTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageUrlTest.php
@@ -50,8 +50,7 @@ class ImageUrlTest extends GraphQLTestBase {
     $this->assertEquals($this->file_url, $result);
 
     // TODO: Add cache checks.
-    //    $this->assertContains('test_tag', $metadata->getCacheTags());
-
+    // $this->assertContains('test_tag', $metadata->getCacheTags());
     // Test that we do not get a file we don't have access to, but the cache
     // tags are still added.
     $result = $this->executeDataProducer('image_url', [
@@ -61,8 +60,8 @@ class ImageUrlTest extends GraphQLTestBase {
     $this->assertNull($result);
 
     // TODO: Add cache checks.
-    //    $this->assertContains('test_tag_forbidden',
-    //    $metadata->getCacheTags());
+    // $this->assertContains('test_tag_forbidden',
+    // $metadata->getCacheTags());
   }
 
 }

--- a/tests/src/Kernel/DataProducer/EntityTest.php
+++ b/tests/src/Kernel/DataProducer/EntityTest.php
@@ -334,7 +334,7 @@ class EntityTest extends GraphQLTestBase {
     ]);
 
     // TODO: Add metadata check.
-    //$this->assertContains('node_list', $metadata->getCacheTags());
+    // $this->assertContains('node_list', $metadata->getCacheTags());
     $this->assertNull($result);
   }
 
@@ -349,7 +349,7 @@ class EntityTest extends GraphQLTestBase {
     ]);
 
     // TODO: Add metadata check.
-    //$this->assertContains('node:1', $metadata->getCacheTags());
+    // $this->assertContains('node:1', $metadata->getCacheTags());
     $this->assertNull($result);
   }
 
@@ -377,7 +377,7 @@ class EntityTest extends GraphQLTestBase {
     ]);
 
     // TODO: Add metadata check.
-    //$this->assertContains('node:1', $metadata->getCacheTags());
+    // $this->assertContains('node:1', $metadata->getCacheTags());
     $this->assertContains('<a href="/node/1" rel="bookmark"><span>' . $this->node->getTitle() . '</span>', $result);
   }
 

--- a/tests/src/Kernel/DataProducer/Routing/RouteEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Routing/RouteEntityTest.php
@@ -207,8 +207,8 @@ class RouteEntityTest extends GraphQLTestBase {
     $this->assertNull($result);
 
     // TODO: Add cache checks.
-    //    $this->assertContains('node_list', $metadata->getCacheTags());
-    //    $this->assertContains('4xx-response', $metadata->getCacheTags());
+    // $this->assertContains('node_list', $metadata->getCacheTags());
+    // $this->assertContains('4xx-response', $metadata->getCacheTags());
   }
 
 }

--- a/tests/src/Kernel/DataProducer/RoutingTest.php
+++ b/tests/src/Kernel/DataProducer/RoutingTest.php
@@ -46,7 +46,7 @@ class RoutingTest extends GraphQLTestBase {
       'path' => '/idontexist',
     ]);
 
-    //    $this->assertContains('4xx-response', $metadata->getCacheTags());
+    // $this->assertContains('4xx-response', $metadata->getCacheTags());
     $this->assertNull($result);
   }
 

--- a/tests/src/Kernel/EntityBufferTest.php
+++ b/tests/src/Kernel/EntityBufferTest.php
@@ -11,7 +11,7 @@ use Drupal\node\Entity\NodeType;
 class EntityBufferTest extends GraphQLTestBase {
 
   /**
-   * @var NodeIDsArray
+   * @var string[]
    */
   protected $nodeIds = [];
 
@@ -29,10 +29,12 @@ class EntityBufferTest extends GraphQLTestBase {
     ])->save();
 
     foreach (range(1, 3) as $i) {
-      $this->nodeIds[] = Node::create([
+      $node = Node::create([
         'title' => 'Node ' . $i,
         'type' => 'test',
-      ])->save();
+      ]);
+      $node->save();
+      $this->nodeIds[] = $node->id();
     }
 
     $schema = <<<GQL

--- a/tests/src/Kernel/EntityBufferTest.php
+++ b/tests/src/Kernel/EntityBufferTest.php
@@ -10,6 +10,9 @@ use Drupal\node\Entity\NodeType;
  */
 class EntityBufferTest extends GraphQLTestBase {
 
+  /**
+   * @var NodeIDsArray
+   */
   protected $nodeIds = [];
 
   /**

--- a/tests/src/Kernel/Framework/PersistedQueriesTest.php
+++ b/tests/src/Kernel/Framework/PersistedQueriesTest.php
@@ -11,6 +11,9 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
  */
 class PersistedQueriesTest extends GraphQLTestBase {
 
+  /**
+   * @var ModulesArray
+   */
   public static $modules = [
     'graphql_persisted_queries_test',
   ];

--- a/tests/src/Kernel/Framework/PersistedQueriesTest.php
+++ b/tests/src/Kernel/Framework/PersistedQueriesTest.php
@@ -12,7 +12,7 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 class PersistedQueriesTest extends GraphQLTestBase {
 
   /**
-   * @var ModulesArray
+   * @var string[]
    */
   public static $modules = [
     'graphql_persisted_queries_test',

--- a/tests/src/Kernel/Framework/ResultCacheTest.php
+++ b/tests/src/Kernel/Framework/ResultCacheTest.php
@@ -240,7 +240,7 @@ GQL;
       )
     );
 
-    // Set the context value to 'a'/
+    // Set the context value to 'a'/.
     $contextKeys->willReturn(new ContextCacheKeys(['a']));
     // This will be stored in the cache key for context 'a'.
     $this->query('{ root }');


### PR DESCRIPTION
exclude name="Drupal.Commenting.InlineComment.InvalidEndChar"
exclude name="Drupal.Commenting.InlineComment.NoSpaceBefore"
exclude name="Drupal.Commenting.InlineComment.SpacingAfter"
exclude name="Drupal.Commenting.InlineComment.SpacingBefore"
exclude name="Drupal.Commenting.InlineComment.SpacingBefore"
exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"
exclude name="Drupal.Commenting.VariableComment.Missing"
exclude name="Drupal.ControlStructures.ControlSignature.NewlineAfterCloseBrace"