### PR TITLE
A few FunctionComment Rules removed

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,15 +36,9 @@
     <exclude name="Drupal.Commenting.FunctionComment.IncorrectTypeHint"/>
     <exclude name="Drupal.Commenting.FunctionComment.InvalidNoReturn"/>
     <exclude name="Drupal.Commenting.FunctionComment.InvalidReturn"/>
-    <exclude name="Drupal.Commenting.FunctionComment.Missing"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
-    <exclude name="Drupal.Commenting.FunctionComment.MissingParamName"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamType"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ParamCommentIndentation"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ParamMissingDefinition"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ParamNameNoMatch"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ReturnCommentIndentation"/>
   </rule>
 
 </ruleset>

--- a/src/Entity/ServerInterface.php
+++ b/src/Entity/ServerInterface.php
@@ -41,7 +41,7 @@ interface ServerInterface extends ConfigEntityInterface {
    * Removes a Persisted Query plugin instance from the persisted queries set.
    *
    * @param string $queryPluginId
-   *  The plugin id to be removed.
+   *   The plugin id to be removed.
    */
   public function removePersistedQueryInstance($queryPluginId);
 

--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -227,6 +227,9 @@ class ServerForm extends EntityForm {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $formState) {
     parent::submitForm($form, $formState);
 

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -35,7 +35,7 @@ class DataProducerPluginManager extends DefaultPluginManager {
    *   An object that implements \Traversable which contains the root paths
    *   keyed by the corresponding namespace to look for plugin implementations.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
-   * *   The module handler.
+   *   *   The module handler.
    * @param \Drupal\Core\Cache\CacheBackendInterface $definitionCacheBackend
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    * @param \Drupal\Core\Cache\Context\CacheContextsManager $contextsManager

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -34,12 +34,12 @@ class DataProducerPluginManager extends DefaultPluginManager {
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths
    *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   * @param \Drupal\Core\Cache\CacheBackendInterface $definitionCacheBackend
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    * @param \Drupal\Core\Cache\Context\CacheContextsManager $contextsManager
    * @param \Drupal\Core\Cache\CacheBackendInterface $resultCacheBackend
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
    *   The module handler.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $definitionCacheBackend
    * @param string|null $pluginInterface
    *   The interface each plugin should implement.
    * @param string $pluginAnnotationName

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -35,11 +35,11 @@ class DataProducerPluginManager extends DefaultPluginManager {
    *   An object that implements \Traversable which contains the root paths
    *   keyed by the corresponding namespace to look for plugin implementations.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   * *   The module handler.
    * @param \Drupal\Core\Cache\CacheBackendInterface $definitionCacheBackend
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    * @param \Drupal\Core\Cache\Context\CacheContextsManager $contextsManager
    * @param \Drupal\Core\Cache\CacheBackendInterface $resultCacheBackend
-   *   The module handler.
    * @param string|null $pluginInterface
    *   The interface each plugin should implement.
    * @param string $pluginAnnotationName

--- a/src/Plugin/GraphQL/DataProducer/Utility/Seek.php
+++ b/src/Plugin/GraphQL/DataProducer/Utility/Seek.php
@@ -27,11 +27,11 @@ class Seek extends DataProducerPluginBase {
 
   /**
    * @param array $input
-   *  The input array.
-   * @param int position
-   *  The position to seek.
+   *   The input array.
+   * @param int $position
+   *   The position to seek.
    * @return mixed
-   *  The element at the specified position.
+   *   The element at the specified position.
    */
   public function resolve(array $input, $position) {
     $array_object = new \ArrayObject($input);

--- a/src/Plugin/GraphQL/DataProducer/XML/XMLAttribute.php
+++ b/src/Plugin/GraphQL/DataProducer/XML/XMLAttribute.php
@@ -27,9 +27,9 @@ class XMLAttribute extends DataProducerPluginBase {
 
   /**
    * @param \DOMElement $dom
-   *  The source (root) DOM element.
+   *   The source (root) DOM element.
    * @param string $name
-   *  The name of the attribute.
+   *   The name of the attribute.
    * @return string
    */
   public function resolve(\DOMElement $dom, $name) {

--- a/src/Plugin/GraphQL/DataProducer/XML/XMLContent.php
+++ b/src/Plugin/GraphQL/DataProducer/XML/XMLContent.php
@@ -24,7 +24,7 @@ class XMLContent extends DataProducerPluginBase {
 
   /**
    * @param \DOMElement $dom
-   *  The source (root) DOM element.
+   *   The source (root) DOM element.
    * @return string
    */
   public function resolve(\DOMElement $dom) {

--- a/src/Plugin/GraphQL/DataProducer/XML/XMLParse.php
+++ b/src/Plugin/GraphQL/DataProducer/XML/XMLParse.php
@@ -24,7 +24,7 @@ class XMLParse extends DataProducerPluginBase {
 
   /**
    * @param string $input
-   *  The source input.
+   *   The source input.
    * @return \DOMElement
    */
   public function resolve($input) {

--- a/src/Plugin/GraphQL/DataProducer/XML/XMLXpath.php
+++ b/src/Plugin/GraphQL/DataProducer/XML/XMLXpath.php
@@ -28,9 +28,9 @@ class XMLXpath extends DataProducerPluginBase {
 
   /**
    * @param \DOMElement $dom
-   *  The source (root) DOM element.
+   *   The source (root) DOM element.
    * @param string $query
-   *  The xpath query.
+   *   The xpath query.
    * @return \DOMElement
    */
   public function resolve(\DOMElement $dom, $query) {

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginOne.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginOne.php
@@ -26,7 +26,7 @@ class PersistedQueryPluginOne extends PersistedQueryPluginBase {
   }
 
   /**
-   * @cover queryMap::resolve
+   * Map between persisted query IDs and corresponding GraphQL queries.
    */
   protected function queryMap() {
     return [

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginOne.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginOne.php
@@ -25,6 +25,9 @@ class PersistedQueryPluginOne extends PersistedQueryPluginBase {
     return $queryMap[$id] ?? NULL;
   }
 
+  /**
+   * @cover queryMap::resolve
+   */
   protected function queryMap() {
     return [
       'query_1' => 'query { field_one }',

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginThree.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginThree.php
@@ -26,7 +26,7 @@ class PersistedQueryPluginThree extends PersistedQueryPluginBase {
   }
 
   /**
-   * @cover queryMap::resolve
+   * Map between persisted query IDs and corresponding GraphQL queries.
    */
   protected function queryMap() {
     return [

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginThree.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginThree.php
@@ -25,6 +25,9 @@ class PersistedQueryPluginThree extends PersistedQueryPluginBase {
     return $queryMap[$id] ?? NULL;
   }
 
+  /**
+   * @cover queryMap::resolve
+   */
   protected function queryMap() {
     return [
       'query_1' => "query { field_three { url } }",

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginTwo.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginTwo.php
@@ -25,6 +25,9 @@ class PersistedQueryPluginTwo extends PersistedQueryPluginBase {
     return $queryMap[$id] ?? NULL;
   }
 
+  /**
+   * @cover queryMap::resolve
+   */
   protected function queryMap() {
     return [
       'query_1' => 'query { field_two }',

--- a/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginTwo.php
+++ b/tests/modules/graphql_persisted_queries_test/src/Plugin/GraphQL/PersistedQuery/PersistedQueryPluginTwo.php
@@ -26,7 +26,7 @@ class PersistedQueryPluginTwo extends PersistedQueryPluginBase {
   }
 
   /**
-   * @cover queryMap::resolve
+   * Map between persisted query IDs and corresponding GraphQL queries.
    */
   protected function queryMap() {
     return [

--- a/tests/src/Kernel/DataProducer/StringTest.php
+++ b/tests/src/Kernel/DataProducer/StringTest.php
@@ -24,6 +24,9 @@ class StringTest extends GraphQLTestBase {
     $this->assertEquals($expected, $result);
   }
 
+  /**
+   * @covers \Drupal\graphql\Plugin\GraphQL\DataProducer\String\Uppercase::resolve
+   */
   public function testUppercaseProvider() {
     return [
       ['test', 'TEST'],

--- a/tests/src/Kernel/DataProducer/StringTest.php
+++ b/tests/src/Kernel/DataProducer/StringTest.php
@@ -25,7 +25,7 @@ class StringTest extends GraphQLTestBase {
   }
 
   /**
-   * @covers \Drupal\graphql\Plugin\GraphQL\DataProducer\String\Uppercase::resolve
+   * Tests the upper case data producer.
    */
   public function testUppercaseProvider() {
     return [

--- a/tests/src/Kernel/EntityBufferTest.php
+++ b/tests/src/Kernel/EntityBufferTest.php
@@ -21,7 +21,7 @@ class EntityBufferTest extends GraphQLTestBase {
   protected $entityBuffer;
 
   /**
-   * @cover EntityBuffer::setUp
+   * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
@@ -54,7 +54,7 @@ GQL;
   }
 
   /**
-   * @cover EntityBuffer::resolve
+   * Tests the entity buffer.
    */
   public function testEntityBuffer() {
     $query = <<<GQL

--- a/tests/src/Kernel/EntityBufferTest.php
+++ b/tests/src/Kernel/EntityBufferTest.php
@@ -20,6 +20,9 @@ class EntityBufferTest extends GraphQLTestBase {
    */
   protected $entityBuffer;
 
+  /**
+   * @cover EntityBuffer::setUp
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -50,6 +53,9 @@ GQL;
     $this->setUpSchema($schema);
   }
 
+  /**
+   * @cover EntityBuffer::resolve
+   */
   public function testEntityBuffer() {
     $query = <<<GQL
       query {

--- a/tests/src/Kernel/EntityUuidBufferTest.php
+++ b/tests/src/Kernel/EntityUuidBufferTest.php
@@ -20,6 +20,9 @@ class EntityUuidBufferTest extends GraphQLTestBase {
    */
   protected $entityBuffer;
 
+  /**
+   * @cover EntityUuidBufferTest::setUp
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -51,6 +54,9 @@ GQL;
     $this->setUpSchema($schema);
   }
 
+  /**
+   * @cover EntityUuidBufferTest::resolve
+   */
   public function testEntityUuidBuffer() {
     $query = <<<GQL
       query {

--- a/tests/src/Kernel/EntityUuidBufferTest.php
+++ b/tests/src/Kernel/EntityUuidBufferTest.php
@@ -21,7 +21,7 @@ class EntityUuidBufferTest extends GraphQLTestBase {
   protected $entityBuffer;
 
   /**
-   * @cover EntityUuidBufferTest::setUp
+   * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
@@ -55,7 +55,7 @@ GQL;
   }
 
   /**
-   * @cover EntityUuidBufferTest::resolve
+   * Tests the entity UUID buffer.
    */
   public function testEntityUuidBuffer() {
     $query = <<<GQL

--- a/tests/src/Kernel/Framework/InvalidPayloadTest.php
+++ b/tests/src/Kernel/Framework/InvalidPayloadTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 class InvalidPayloadTest extends GraphQLTestBase {
 
   /**
-   * @cover InvalidPayloadTest::setUp
+   * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
@@ -28,7 +28,7 @@ GQL;
   }
 
   /**
-   * @cover InvalidPayloadTest::resolve
+   * Tests the empty payload.
    */
   public function testEmptyPayload() {
     $request = Request::create('/graphql/test', 'POST', [], [], [], [], '{ invalid');

--- a/tests/src/Kernel/Framework/InvalidPayloadTest.php
+++ b/tests/src/Kernel/Framework/InvalidPayloadTest.php
@@ -12,6 +12,9 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class InvalidPayloadTest extends GraphQLTestBase {
 
+  /**
+   * @cover InvalidPayloadTest::setUp
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -24,6 +27,9 @@ GQL;
     $this->setUpSchema($schema);
   }
 
+  /**
+   * @cover InvalidPayloadTest::resolve
+   */
   public function testEmptyPayload() {
     $request = Request::create('/graphql/test', 'POST', [], [], [], [], '{ invalid');
     $this->container->get('http_kernel')->handle($request);

--- a/tests/src/Kernel/Framework/UserPermissionsContextTest.php
+++ b/tests/src/Kernel/Framework/UserPermissionsContextTest.php
@@ -15,6 +15,9 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
  */
 class UserPermissionsContextTest extends GraphQLTestBase {
 
+  /**
+   * @cover UserPermissionsContextTest::resolve
+   */
   protected function setUp() {
     parent::setUp();
 

--- a/tests/src/Kernel/Framework/UserPermissionsContextTest.php
+++ b/tests/src/Kernel/Framework/UserPermissionsContextTest.php
@@ -16,7 +16,7 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 class UserPermissionsContextTest extends GraphQLTestBase {
 
   /**
-   * @cover UserPermissionsContextTest::resolve
+   * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();

--- a/tests/src/Kernel/ResolverBuilderTest.php
+++ b/tests/src/Kernel/ResolverBuilderTest.php
@@ -348,7 +348,7 @@ GQL;
   }
 
   /**
-   * @covers ::defaultValue
+   * Tests the composite default value resolver.
    */
   public function testCompositeDefaultValue() {
 

--- a/tests/src/Kernel/ResolverBuilderTest.php
+++ b/tests/src/Kernel/ResolverBuilderTest.php
@@ -347,6 +347,9 @@ GQL;
     ]);
   }
 
+  /**
+   * @covers ::defaultValue
+   */
   public function testCompositeDefaultValue() {
 
     $this->mockResolver('Query', 'tree', ['name' => 'some tree', 'id' => 5]);


### PR DESCRIPTION
exclude name="Drupal.Commenting.FunctionComment.ReturnCommentIndentation"
exclude name="Drupal.Commenting.FunctionComment.ParamNameNoMatch"
exclude name="Drupal.Commenting.FunctionComment.ParamMissingDefinition"
exclude name="Drupal.Commenting.FunctionComment.ParamCommentIndentation"
exclude name="Drupal.Commenting.FunctionComment.MissingParamName"
exclude name="Drupal.Commenting.FunctionComment.Missing"