### PR TITLE
A few function comment rules and doc comment rules removed

### DIFF
--- a/graphql.install
+++ b/graphql.install
@@ -1,6 +1,10 @@
 <?php
 
 /**
+ * @file
+ */
+
+/**
  * Implements hook_requirements().
  */
 function graphql_requirements($phase) {

--- a/graphql.install
+++ b/graphql.install
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Install, update and uninstall functions for the GraphQL module.
  */
 
 /**

--- a/graphql.module
+++ b/graphql.module
@@ -1,6 +1,10 @@
 <?php
 
 /**
+ * @file
+ */
+
+/**
  * Implements hook_help().
  */
 function graphql_help($routeName) {

--- a/graphql.module
+++ b/graphql.module
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Primary module hooks for GraphQL module.
  */
 
 /**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,14 +28,6 @@
     <exclude name="Drupal.Commenting.DocComment.ParamGroup"/>
     <exclude name="Drupal.Commenting.DocComment.ShortFullStop"/>
     <exclude name="Drupal.Commenting.DocComment.SpacingAfter"/>
-    <exclude name="Drupal.Commenting.DocComment.SpacingBeforeTags"/>
-    <exclude name="Drupal.Commenting.DocComment.TagGroupSpacing"/>
-    <exclude name="Drupal.Commenting.DocCommentAlignment.SpaceBeforeStar"/>
-    <exclude name="Drupal.Commenting.FileComment.Missing"/>
-    <exclude name="Drupal.Commenting.FunctionComment.IncorrectParamVarName"/>
-    <exclude name="Drupal.Commenting.FunctionComment.IncorrectTypeHint"/>
-    <exclude name="Drupal.Commenting.FunctionComment.InvalidNoReturn"/>
-    <exclude name="Drupal.Commenting.FunctionComment.InvalidReturn"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamType"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,6 +31,7 @@
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamType"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
+    <exclude name="Drupal.Commenting.FunctionComment.InvalidNoReturn"/>
   </rule>
 
 </ruleset>

--- a/src/GraphQL/Buffers/BufferBase.php
+++ b/src/GraphQL/Buffers/BufferBase.php
@@ -138,9 +138,10 @@ abstract class BufferBase {
    *
    * @param array $buffer
    *   The buffer as an array.
-   *
+   * @codingStandardsIgnoreStart
    * @return array
    *   The resolved results, keyed by their corresponding buffer item array key.
+   * @codingStandardsIgnoreEnd
    */
   protected function resolveBufferArray(array $buffer) {
     throw new \LogicException('Method not implemented.');

--- a/src/GraphQL/Buffers/BufferBase.php
+++ b/src/GraphQL/Buffers/BufferBase.php
@@ -138,10 +138,9 @@ abstract class BufferBase {
    *
    * @param array $buffer
    *   The buffer as an array.
-   * @codingStandardsIgnoreStart
+   *
    * @return array
    *   The resolved results, keyed by their corresponding buffer item array key.
-   * @codingStandardsIgnoreEnd
    */
   protected function resolveBufferArray(array $buffer) {
     throw new \LogicException('Method not implemented.');

--- a/src/GraphQL/Execution/FieldContext.php
+++ b/src/GraphQL/Execution/FieldContext.php
@@ -97,7 +97,7 @@ class FieldContext implements RefinableCacheableDependencyInterface {
    * @param string $name
    *   The name of the context.
    *
-   * @return boolean
+   * @return bool
    *   TRUE if the context exists, FALSE Otherwise.
    */
   public function hasContextValue($name) {

--- a/src/GraphQL/Execution/ResolveContext.php
+++ b/src/GraphQL/Execution/ResolveContext.php
@@ -177,7 +177,7 @@ class ResolveContext implements RefinableCacheableDependencyInterface {
    * @param string $name
    *   The name of the context.
    *
-   * @return boolean
+   * @return bool
    *   TRUE if the context exists, FALSE Otherwise.
    */
   public function hasContextValue(ResolveInfo $info, $name) {

--- a/src/GraphQL/Resolver/Context.php
+++ b/src/GraphQL/Resolver/Context.php
@@ -27,7 +27,7 @@ class Context implements ResolverInterface {
    * Context constructor.
    *
    * @param $name
-   * @param NULL $default
+   * @param $default
    */
   public function __construct($name, $default = NULL) {
     $this->name = $name;

--- a/src/GraphQL/Resolver/Path.php
+++ b/src/GraphQL/Resolver/Path.php
@@ -46,7 +46,7 @@ class Path implements ResolverInterface {
    *
    * @param $type
    * @param $path
-   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface|NULL $value
+   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null $value
    */
   public function __construct($type, $path, ResolverInterface $value = NULL) {
     $this->type = $type;

--- a/src/GraphQL/Resolver/SourceContext.php
+++ b/src/GraphQL/Resolver/SourceContext.php
@@ -26,7 +26,7 @@ class SourceContext implements ResolverInterface {
    * SourceContext constructor.
    *
    * @param $name
-   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface|NULL $source
+   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null $source
    */
   public function __construct($name, ResolverInterface $source = NULL) {
     $this->name = $name;

--- a/src/GraphQL/ResolverBuilder.php
+++ b/src/GraphQL/ResolverBuilder.php
@@ -34,11 +34,11 @@ class ResolverBuilder {
   }
 
   /**
-   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface[] $resolvers
+   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface[]|array $resolvers
    *
    * @return \Drupal\graphql\GraphQL\Resolver\Composite
    */
-  public function compose(array ...$resolvers) {
+  public function compose(ResolverInterface ...$resolvers) {
     return new Composite($resolvers);
   }
 

--- a/src/GraphQL/ResolverBuilder.php
+++ b/src/GraphQL/ResolverBuilder.php
@@ -38,7 +38,7 @@ class ResolverBuilder {
    *
    * @return \Drupal\graphql\GraphQL\Resolver\Composite
    */
-  public function compose(ResolverInterface ...$resolvers) {
+  public function compose(array ...$resolvers) {
     return new Composite($resolvers);
   }
 

--- a/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
@@ -142,6 +142,7 @@ class DataProducerProxy implements ResolverInterface {
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $field
    *
    * @return mixed
+   *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function resolve($value, $args, ResolveContext $context, ResolveInfo $info, FieldContext $field) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityAccess.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityAccess.php
@@ -32,8 +32,8 @@ class EntityAccess extends DataProducerPluginBase {
 
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param NULL $operation
-   * @param NULL $user
+   * @param $operation
+   * @param $user
    *
    * @return bool|\Drupal\Core\Access\AccessResultInterface
    */

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -134,12 +134,12 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    * @param array|null $bundles
    * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $id, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve($type, $id, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $id);
 
     return new Deferred(function () use ($type, $id, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -132,14 +132,14 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
    * @param $id
    * @param $language
    * @param array|null $bundles
-   * @param bool $access
+   * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $id, $language, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve($type, $id, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $id);
 
     return new Deferred(function () use ($type, $id, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -130,16 +130,16 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
   /**
    * @param $type
    * @param $id
-   * @param NULL $language
+   * @param $language
    * @param array|null $bundles
    * @param bool $access
-   * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $id, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve($type, $id, $language, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $id);
 
     return new Deferred(function () use ($type, $id, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -132,14 +132,14 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
    * @param $uuid
    * @param array|string $language
    * @param array|string $bundles
-   * @param bool $access
+   * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $uuid, $language, $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve($type, $uuid, $language, $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $uuid);
 
     return new Deferred(function () use ($type, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -133,13 +133,13 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
    * @param array|string $language
    * @param array|string $bundles
    * @param bool $access
-   * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $uuid, $language, $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve($type, $uuid, $language, $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $uuid);
 
     return new Deferred(function () use ($type, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -134,12 +134,12 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
    * @param array|string $bundles
    * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, $uuid, $language, $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve($type, $uuid, $language, $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $uuid);
 
     return new Deferred(function () use ($type, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -130,16 +130,16 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
   /**
    * @param $type
    * @param array $ids
-   * @param NULL $language
+   * @param $language
    * @param array|null $bundles
    * @param bool $access
-   * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
    */
-  public function resolve($type, array $ids, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve($type, array $ids, $language, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     $resolver = $this->entityBuffer->add($type, $ids);
 
     return new Deferred(function () use ($type, $ids, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadMultiple.php
@@ -134,7 +134,7 @@ class EntityLoadMultiple extends DataProducerPluginBase implements ContainerFact
    * @param array|null $bundles
    * @param bool $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
@@ -91,12 +91,12 @@ class EntityTranslation extends DataProducerPluginBase implements ContainerFacto
    * @param \Drupal\Core\Entity\EntityInterface $entity
    * @param $language
    * @param bool $access
-   * @param \Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\AccountInterface|NULL $accessUser
+   * @param \Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\AccountInterface|null $accessUser
    * @param string $accessOperation
    *
    * @return |null
    */
-  public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation) {
+  public function resolve(EntityInterface $entity, $language, bool $access, ?AccountInterface $accessUser, string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $entity = $entity->getTranslation($language);
       $entity->addCacheContexts(["static:language:{$language}"]);

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
@@ -92,11 +92,11 @@ class EntityTranslation extends DataProducerPluginBase implements ContainerFacto
    * @param $language
    * @param bool|null $access
    * @param \Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    *
    * @return |null
    */
-  public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, string $accessOperation) {
+  public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $entity = $entity->getTranslation($language);
       $entity->addCacheContexts(["static:language:{$language}"]);

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
@@ -90,13 +90,13 @@ class EntityTranslation extends DataProducerPluginBase implements ContainerFacto
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
    * @param $language
-   * @param bool $access
+   * @param bool|null $access
    * @param \Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\AccountInterface|null $accessUser
    * @param string $accessOperation
    *
    * @return |null
    */
-  public function resolve(EntityInterface $entity, $language, bool $access, ?AccountInterface $accessUser, string $accessOperation) {
+  public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $entity = $entity->getTranslation($language);
       $entity->addCacheContexts(["static:language:{$language}"]);

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
@@ -89,13 +89,13 @@ class EntityTranslations extends DataProducerPluginBase implements ContainerFact
 
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param bool $access
+   * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    *
    * @return array|null
    */
-  public function resolve(EntityInterface $entity, bool $access , ?AccountInterface $accessUser, string $accessOperation) {
+  public function resolve(EntityInterface $entity, ?bool $access , ?AccountInterface $accessUser, ?string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $languages = $entity->getTranslationLanguages();
 

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
@@ -90,12 +90,12 @@ class EntityTranslations extends DataProducerPluginBase implements ContainerFact
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
    * @param bool $access
-   * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    *
    * @return array|null
    */
-  public function resolve(EntityInterface $entity, ?bool $access , ?AccountInterface $accessUser, ?string $accessOperation) {
+  public function resolve(EntityInterface $entity, bool $access , ?AccountInterface $accessUser, string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $languages = $entity->getTranslationLanguages();
 

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -134,14 +134,14 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
    * @param $field
    * @param $language
    * @param array|null $bundles
-   * @param bool $access
+   * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred|null
    */
-  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -132,16 +132,16 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
    * @param $field
-   * @param NULL $language
+   * @param $language
    * @param array|null $bundles
    * @param bool $access
-   * @param \Drupal\Core\Session\AccountInterface|NULL $accessUser
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred|null
    */
-  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -136,12 +136,12 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
    * @param array|null $bundles
    * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
-   * @param string $accessOperation
+   * @param string|null $accessOperation
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred|null
    */
-  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context) {
+  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceLayoutRevisions.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceLayoutRevisions.php
@@ -147,7 +147,7 @@ class EntityReferenceLayoutRevisions extends DataProducerPluginBase implements C
    * @return \GraphQL\Deferred|null
    *   A promise that will return entities or NULL if there aren't any.
    */
-  public function resolve(EntityInterface $entity, string $field, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+  public function resolve(EntityInterface $entity, string $field, ?string $language, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context): ?Deferred {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceRevisions.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReferenceRevisions.php
@@ -147,7 +147,7 @@ class EntityReferenceRevisions extends DataProducerPluginBase implements Contain
    * @return \GraphQL\Deferred|null
    *   A promise that will return entities or NULL if there aren't any.
    */
-  public function resolve(EntityInterface $entity, string $field, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+  public function resolve(EntityInterface $entity, string $field, ?string $language, ?array $bundles, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context): ?Deferred {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
+++ b/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
@@ -145,7 +145,7 @@ class TaxonomyLoadTree extends DataProducerPluginBase implements ContainerFactor
    * @return \GraphQL\Deferred|null
    *   A promise that will return entities or NULL if there aren't any.
    */
-  public function resolve(string $vid, ?int $parent, ?int $max_depth, ?string $language, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+  public function resolve(string $vid, int $parent, ?int $max_depth, ?string $language, bool $access, ?AccountInterface $accessUser, string $accessOperation, FieldContext $context): ?Deferred {
     if (!isset($max_depth)) {
       $max_depth = self::MAX_DEPTH;
     }

--- a/tests/src/Kernel/DataProducer/XML/XMLTestBase.php
+++ b/tests/src/Kernel/DataProducer/XML/XMLTestBase.php
@@ -23,6 +23,7 @@ class XMLTestBase extends GraphQLTestBase {
 
   /**
    * Returns the source of the test document.
+   *
    * @return bool|string
    */
   public function getDocumentSource() {

--- a/tests/src/Traits/HttpRequestTrait.php
+++ b/tests/src/Traits/HttpRequestTrait.php
@@ -59,13 +59,13 @@ trait HttpRequestTrait {
    *
    * @param string[] $queries
    *   A set of queries to be executed in one go.
-   * @param \Drupal\graphql\Entity\Server $server
+   * @param \Drupal\graphql\Entity\ServerInterface $server
    *   The server instance.
    *
    * @return \Symfony\Component\HttpFoundation\Response
    *   The http response object.
    */
-  protected function batchedQueries(array $queries, Server $server = NULL) {
+  protected function batchedQueries(array $queries, ServerInterface $server = NULL) {
     $server = $server ?: $this->server;
     if (!($server instanceof Server)) {
       throw new \LogicException('Invalid server.');

--- a/tests/src/Traits/HttpRequestTrait.php
+++ b/tests/src/Traits/HttpRequestTrait.php
@@ -65,7 +65,7 @@ trait HttpRequestTrait {
    * @return \Symfony\Component\HttpFoundation\Response
    *   The http response object.
    */
-  protected function batchedQueries(array $queries, ServerInterface $server = NULL) {
+  protected function batchedQueries(array $queries, Server $server = NULL) {
     $server = $server ?: $this->server;
     if (!($server instanceof Server)) {
       throw new \LogicException('Invalid server.');


### PR DESCRIPTION
exclude name="Drupal.Commenting.DocComment.SpacingBeforeTags"
exclude name="Drupal.Commenting.DocComment.TagGroupSpacing"
exclude name="Drupal.Commenting.DocCommentAlignment.SpaceBeforeStar"
exclude name="Drupal.Commenting.FileComment.Missing"
exclude name="Drupal.Commenting.FunctionComment.IncorrectParamVarName"
exclude name="Drupal.Commenting.FunctionComment.IncorrectTypeHint"
exclude name="Drupal.Commenting.FunctionComment.InvalidNoReturn"
exclude name="Drupal.Commenting.FunctionComment.InvalidReturn"