### PR TITLE
Drupal 9 compatibility for 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ env:
     - SIMPLETEST_DB=mysql://root:@127.0.0.1/graphql
     - TRAVIS=true
   matrix:
-    - DRUPAL_CORE=8.8.x
+    - DRUPAL_CORE=9.0.x
     - DRUPAL_CORE=8.9.x
+    - DRUPAL_CORE=8.8.x
 
 matrix:
   # Don't wait for the allowed failures to build.
@@ -28,6 +29,17 @@ matrix:
         - DRUPAL_CORE=8.8.x
         # Only run code coverage on the latest php and drupal versions.
         - WITH_PHPDBG_COVERAGE=true
+  # Drupal 9 requires PHP 7.3 or higher
+  exclude:
+    - php: 7.0
+      env:
+        - DRUPAL_CORE=9.0.x
+    - php: 7.1
+      env:
+        - DRUPAL_CORE=9.0.x
+    - php: 7.2
+      env:
+        - DRUPAL_CORE=9.0.x
   allow_failures:
     # Allow the code coverage report to fail.
     - php: 7.3

--- a/graphql.info.yml
+++ b/graphql.info.yml
@@ -3,4 +3,4 @@ type: module
 description: 'Base module for integrating GraphQL with Drupal.'
 package: GraphQL
 configure: graphql.config_page
-core: 8.x
+core_version_requirement: ^8.8 || ^9

--- a/modules/graphql_core/graphql_core.info.yml
+++ b/modules/graphql_core/graphql_core.info.yml
@@ -1,7 +1,6 @@
 name: GraphQL Core
 type: module
 description: 'Provides type system plugins and derivers on behalf of core modules.'
-package: GraphQL
-core: 8.x
+package: Testing
 dependencies:
   - graphql

--- a/modules/graphql_core/tests/modules/graphql_block_test/graphql_block_test.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_block_test/graphql_block_test.info.yml
@@ -1,6 +1,6 @@
 name: 'GraphQL Test: Blocks'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - block
   - block_content

--- a/modules/graphql_core/tests/modules/graphql_breadcrumbs_test/graphql_breadcrumbs_test.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_breadcrumbs_test/graphql_breadcrumbs_test.info.yml
@@ -2,6 +2,6 @@ name: GraphQL Breadcrumbs test
 type: module
 description: 'Test for breadcrumbs.'
 package: GraphQL
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
 - graphql_breadcrumbs

--- a/modules/graphql_core/tests/modules/graphql_context_test/graphql_context_test.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_context_test/graphql_context_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Context Test
 description: Test contexts in graphql schema.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql_core

--- a/modules/graphql_core/tests/modules/graphql_requests_test/graphql_requests_test.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_requests_test/graphql_requests_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Requests Test
 description: Dummy callbacks for internal request testing.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql_core

--- a/modules/graphql_core/tests/modules/graphql_test_menu/graphql_test_menu.info.yml
+++ b/modules/graphql_core/tests/modules/graphql_test_menu/graphql_test_menu.info.yml
@@ -1,5 +1,5 @@
 name: 'GraphQL Tests: Menu'
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - system

--- a/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Entity/EntityByIdTest.php
@@ -32,7 +32,7 @@ class EntityByIdTest extends GraphQLContentTestBase {
     parent::setUp();
 
     /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $languageStorage */
-    $languageStorage = $this->container->get('entity.manager')->getStorage('configurable_language');
+    $languageStorage = $this->container->get('entity_type.manager')->getStorage('configurable_language');
 
     $language = $languageStorage->create([
       'id' => $this->chineseSimplifiedLangcode,

--- a/modules/graphql_core/tests/src/Kernel/GraphQLCoreTestBase.php
+++ b/modules/graphql_core/tests/src/Kernel/GraphQLCoreTestBase.php
@@ -14,6 +14,7 @@ class GraphQLCoreTestBase extends GraphQLTestBase {
    */
   public static $modules = [
     'graphql_core',
+    'path_alias',
     'user',
   ];
 

--- a/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Images/ImageFieldTest.php
@@ -70,7 +70,7 @@ class ImageFieldTest extends GraphQLContentTestBase {
           'image' => [[
             'alt' => $a->image->alt,
             'title' => $a->image->title,
-            'entity' => ['url' => $a->image->entity->url()],
+            'entity' => ['url' => $a->image->entity->createFileUrl(FALSE)],
             'width' => $a->image[0]->width,
             'height' => $a->image[0]->height,
             'thumbnailImage' => [

--- a/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
+++ b/modules/graphql_core/tests/src/Kernel/Menu/MenuTest.php
@@ -55,7 +55,7 @@ class MenuTest extends GraphQLCoreTestBase {
     /** @var \Drupal\Core\Menu\MenuTreeStorageInterface $menuStorage */
     $menuStorage = $this->container->get('entity_type.manager')->getStorage('menu');
     $menu = $menuStorage->load('test');
-    $this->assertTrue($menu);
+    $this->assertIsObject($menu);
 
     /** @var \Drupal\Core\Menu\MenuLinkTreeInterface $menuTree */
     $menuTree = $this->container->get('menu.link_tree');

--- a/src/Form/EntityQueryMapImportForm.php
+++ b/src/Form/EntityQueryMapImportForm.php
@@ -73,7 +73,7 @@ class EntityQueryMapImportForm extends EntityForm {
     $entity->set('map', array_flip((array) json_decode($json)));
     $entity->save();
 
-    drupal_set_message($this->t('Saved the query map version %id.', [
+    $this->messenger()->addMessage($this->t('Saved the query map version %id.', [
       '%id' => $entity->id(),
     ]));
 

--- a/src/Routing/QueryRouteEnhancer.php
+++ b/src/Routing/QueryRouteEnhancer.php
@@ -3,26 +3,24 @@
 namespace Drupal\graphql\Routing;
 
 use Drupal\Component\Utility\NestedArray;
-use Drupal\Core\Routing\Enhancer\RouteEnhancerInterface;
-use Drupal\graphql\GraphQL\QueryProvider\QueryProviderInterface;
+use Drupal\Core\Routing\EnhancerInterface;
 use Drupal\graphql\Utility\JsonHelper;
 use GraphQL\Server\Helper;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 
-class QueryRouteEnhancer implements RouteEnhancerInterface {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function applies(Route $route) {
-    return $route->hasDefault('_graphql');
-  }
+class QueryRouteEnhancer implements EnhancerInterface {
 
   /**
    * {@inheritdoc}
    */
   public function enhance(array $defaults, Request $request) {
+    $route = $defaults[RouteObjectInterface::ROUTE_OBJECT];
+    if (!$route->hasDefault('_graphql')) {
+      return $defaults;
+    }
+
     $helper = new Helper();
     $method = $request->getMethod();
     $body = $this->extractBody($request);

--- a/tests/modules/graphql_enum_test/graphql_enum_test.info.yml
+++ b/tests/modules/graphql_enum_test/graphql_enum_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Enumeration Test
 description: Test enumeration plugins.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql

--- a/tests/modules/graphql_override_test/graphql_override_test.info.yml
+++ b/tests/modules/graphql_override_test/graphql_override_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Override Test
 description: Test plugin overrides in graphql schema.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql_plugin_test

--- a/tests/modules/graphql_plugin_test/graphql_plugin_test.info.yml
+++ b/tests/modules/graphql_plugin_test/graphql_plugin_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Plugin Test
 description: Test plugin based graphql schema.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql

--- a/tests/modules/graphql_test/graphql_test.info.yml
+++ b/tests/modules/graphql_test/graphql_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: GraphQL Test
 description: Provides a default schema plugin for testing.
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 hidden: TRUE
 dependencies:
 - graphql

--- a/tests/src/Kernel/Framework/UploadMutationTest.php
+++ b/tests/src/Kernel/Framework/UploadMutationTest.php
@@ -18,7 +18,8 @@ class UploadMutationTest extends GraphQLTestBase {
    */
   public function testFileUpload() {
     // Create dummy file, since symfony will test if it exists..
-    $file = file_directory_temp() . '/graphql_upload_test.txt';
+    $file = \Drupal::service('file_system')
+        ->getTempDirectory() . '/graphql_upload_test.txt';
     touch($file);
 
     // Mock a mutation that accepts the upload input and just returns

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -14,8 +14,6 @@ use Drupal\Tests\graphql\Traits\MockSchemaTrait;
 use Drupal\Tests\graphql\Traits\MockGraphQLPluginTrait;
 use Drupal\Tests\graphql\Traits\QueryFileTrait;
 use Drupal\Tests\graphql\Traits\QueryResultAssertionTrait;
-use PHPUnit_Framework_Error_Notice;
-use PHPUnit_Framework_Error_Warning;
 
 /**
  * Base class for GraphQL tests.
@@ -101,8 +99,6 @@ abstract class GraphQLTestBase extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
     $this->injectTypeSystemPluginManagers($this->container);
-
-    PHPUnit_Framework_Error_Warning::$enabled = FALSE;
 
     $this->injectAccount();
     $this->installConfig('system');

--- a/tests/src/Traits/MockGraphQLPluginTrait.php
+++ b/tests/src/Traits/MockGraphQLPluginTrait.php
@@ -372,7 +372,7 @@ trait MockGraphQLPluginTrait {
    * @param mixed|null $applies
    *   A result for the types "applies" method. Defaults to `TRUE`.
    *
-   * @return \PHPUnit_Framework_MockObject_MockObject
+   * @return \PHPUnit\Framework\MockObject\MockObject
    *   The type mock object.
    */
   protected function mockType($id, array $definition, $applies = TRUE, $builder = NULL) {
@@ -463,7 +463,7 @@ trait MockGraphQLPluginTrait {
    *   A result for this mutation. Can be a value or a callback. If omitted, no
    *   resolve method mock will be attached.
    *
-   * @return \PHPUnit_Framework_MockObject_MockObject
+   * @return \PHPUnit\Framework\MockObject\MockObject
    *   The mutation mock object.
    */
   protected function mockMutation($id, array $definition, $result = NULL, $builder = NULL) {
@@ -513,7 +513,7 @@ trait MockGraphQLPluginTrait {
    * @param array $definition
    *   The plugin definition. Will be merged with the interface defaults.
    *
-   * @return \PHPUnit_Framework_MockObject_MockObject
+   * @return \PHPUnit\Framework\MockObject\MockObject
    *   The interface mock object.
    */
   protected function mockInterface($id, array $definition, $builder = NULL) {
@@ -555,7 +555,7 @@ trait MockGraphQLPluginTrait {
    * @param array $definition
    *   The plugin definition. Will be merged with the union defaults.
    *
-   * @return \PHPUnit_Framework_MockObject_MockObject
+   * @return \PHPUnit\Framework\MockObject\MockObject
    *   The union mock object.
    */
   protected function mockUnion($id, array $definition, $builder = NULL) {


### PR DESCRIPTION
Fixes #1011.
Based on, replaces and closes #1012 (with thanks to @damienmckenna).

Because the GraphQL v4 module isn't compatible with Drupal 8, contains breaking changes and requires a lot of rewriting, it will help the community to be able migrate to Drupal 9 sooner and by changing fewer things at each step.

Also, v4 is still in beta and therefore not covered by the security advisory policy, so may be not ready for production.

Once migrated to D9, users will be able to perform the v4 upgrade.

The tests pass on Travis CI for Drupal 8.8, 8.9 and 9.0.

Our D8.9 site's own unit tests pass with these changes.
