### PR TITLE
Removed a couple of rules

### DIFF
--- a/examples/graphql_example/src/Plugin/GraphQL/DataProducer/QueryArticles.php
+++ b/examples/graphql_example/src/Plugin/GraphQL/DataProducer/QueryArticles.php
@@ -62,7 +62,6 @@ class QueryArticles extends DataProducerPluginBase implements ContainerFactoryPl
    *   The plugin id.
    * @param mixed $pluginDefinition
    *   The plugin definition.
-   *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityManager
    *
    * @codeCoverageIgnore

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,14 +7,6 @@
 
   <rule ref="Drupal">
     <!-- TODO: those rules are disabled for now until we fix the coding standards for them. -->
-    <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace"/>
-    <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace"/>
-    <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd"/>
-    <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
-    <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
-    <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma"/>
-    <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
-    <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeBrace"/>
     <exclude name="Drupal.Arrays.Array.CommaLastItem"/>
     <exclude name="Drupal.Arrays.Array.LongLineDeclaration"/>
     <exclude name="Drupal.Arrays.DisallowLongArraySyntax.Found"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,11 +23,7 @@
     <exclude name="Drupal.Classes.PropertyDeclaration.ScopeMissing"/>
     <exclude name="Drupal.Classes.UnusedUseStatement.UnusedUse"/>
     <exclude name="Drupal.Commenting.ClassComment.Missing"/>
-    <exclude name="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace"/>
     <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
-    <exclude name="Drupal.Commenting.DocComment.ParamGroup"/>
-    <exclude name="Drupal.Commenting.DocComment.ShortFullStop"/>
-    <exclude name="Drupal.Commenting.DocComment.SpacingAfter"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamType"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>

--- a/src/Annotation/PersistedQuery.php
+++ b/src/Annotation/PersistedQuery.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\graphql\Annotation;
 
-
 use Doctrine\Common\Annotations\AnnotationException;
 use Drupal\Component\Annotation\Plugin;
 

--- a/src/Controller/ServerListBuilder.php
+++ b/src/Controller/ServerListBuilder.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 
 /**
- * Class ServerListBuilder
+ * Class ServerListBuilder.
  *
  * @package Drupal\graphql\Controller
  *

--- a/src/Entity/ServerInterface.php
+++ b/src/Entity/ServerInterface.php
@@ -23,7 +23,7 @@ interface ServerInterface extends ConfigEntityInterface {
   public function executeBatch(array $operations);
 
   /**
-   * Retrieves the server configuration
+   * Retrieves the server configuration.
    *
    * @return \GraphQL\Server\ServerConfig
    *   The server configuration.
@@ -33,7 +33,7 @@ interface ServerInterface extends ConfigEntityInterface {
   /**
    * Adds a Persisted Query plugin instance to the persisted queries set.
    *
-   * @param PersistedQueryPluginInterface $queryPlugin
+   * @param \Drupal\graphql\Plugin\PersistedQueryPluginInterface $queryPlugin
    */
   public function addPersistedQueryInstance(PersistedQueryPluginInterface $queryPlugin);
 

--- a/src/Form/PersistedQueriesForm.php
+++ b/src/Form/PersistedQueriesForm.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PersistedQueriesForm extends EntityForm {
 
   /**
-   * @var PersistedQueryPluginManager
+   * @var \Drupal\graphql\Plugin\PersistedQueryPluginManager
    */
   protected $persistedQueryPluginManager;
 
@@ -183,7 +183,7 @@ class PersistedQueriesForm extends EntityForm {
   /**
    * Returns an array with all the available persisted query plugins.
    *
-   * @return PersistedQueryPluginInterface[]
+   * @return \Drupal\graphql\Plugin\PersistedQueryPluginInterface[]
    */
   protected function getAllPersistedQueryPlugins() {
     $plugins = [];

--- a/src/GraphQL/Execution/Executor.php
+++ b/src/GraphQL/Execution/Executor.php
@@ -251,7 +251,7 @@ class Executor implements ExecutorImplementation {
     $event = new OperationEvent($this->context);
     $this->dispatcher->dispatch(OperationEvent::GRAPHQL_OPERATION_BEFORE, $event);
 
-    return $executor->doExecute()->then(function ($result)  {
+    return $executor->doExecute()->then(function ($result) {
       $event = new OperationEvent($this->context, $result);
       $this->dispatcher->dispatch(OperationEvent::GRAPHQL_OPERATION_AFTER, $event);
 

--- a/src/GraphQL/ResolverBuilder.php
+++ b/src/GraphQL/ResolverBuilder.php
@@ -43,7 +43,7 @@ class ResolverBuilder {
   }
 
   /**
-   * @param ResolverInterface $callback
+   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface $callback
    *
    * @return \Drupal\graphql\GraphQL\Resolver\Tap
    */
@@ -52,7 +52,7 @@ class ResolverBuilder {
   }
 
   /**
-   * @param ResolverInterface $callback
+   * @param \Drupal\graphql\GraphQL\Resolver\ResolverInterface $callback
    *
    * @return \Drupal\graphql\GraphQL\Resolver\Map
    */

--- a/src/GraphQL/Utility/Introspection.php
+++ b/src/GraphQL/Utility/Introspection.php
@@ -16,7 +16,6 @@ class Introspection {
    *
    * @return array
    *   The introspection result as an array.
-   *
    */
   public function introspect(ServerInterface $server) {
     $operation = new OperationParams();

--- a/src/GraphQL/Utility/JsonHelper.php
+++ b/src/GraphQL/Utility/JsonHelper.php
@@ -14,7 +14,7 @@ class JsonHelper {
    *   The decoded values.
    */
   public static function decodeParams(array $values = []) {
-    return array_map(function($value) {
+    return array_map(function ($value) {
       if (!is_string($value)) {
         return $value;
       }

--- a/src/PermissionProvider.php
+++ b/src/PermissionProvider.php
@@ -9,7 +9,7 @@ class PermissionProvider {
   use StringTranslationTrait;
 
   /**
-   * The entity type manager service
+   * The entity type manager service.
    *
    * @var \Drupal\Core\Authentication\AuthenticationCollectorInterface
    */

--- a/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerProxy.php
@@ -179,7 +179,7 @@ class DataProducerProxy implements ResolverInterface {
    * @throws \Exception
    */
   protected function prepare($value, $args, ResolveContext $context, ResolveInfo $info, FieldContext $field) {
-    /** @var DataProducerPluginInterface $plugin */
+    /** @var \Drupal\graphql\Plugin\DataProducerPluginInterface $plugin */
     $plugin = $this->pluginManager->createInstance($this->id, $this->config);
     $contexts = $plugin->getContextDefinitions();
 

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityRendered.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityRendered.php
@@ -95,19 +95,19 @@ class EntityRendered extends DataProducerPluginBase implements ContainerFactoryP
 
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param string|null $mode
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   * @param string|null $mode
    *
    * @return string
    */
-  public function resolve(EntityInterface $entity, $mode = NULL, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve(EntityInterface $entity, RefinableCacheableDependencyInterface $metadata, $mode = NULL) {
     $mode = $mode ?? 'full';
     $builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
     $view = $builder->view($entity, $mode, $entity->language()->getId());
 
     $context = new RenderContext();
     /** @var \GraphQL\Executor\ExecutionResult|\GraphQL\Executor\ExecutionResult[] $result */
-    $result = $this->renderer->executeInRenderContext($context, function() use ($view) {
+    $result = $this->renderer->executeInRenderContext($context, function () use ($view) {
       return $this->renderer->render($view);
     });
 

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityRendered.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityRendered.php
@@ -95,12 +95,12 @@ class EntityRendered extends DataProducerPluginBase implements ContainerFactoryP
 
   /**
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    * @param string|null $mode
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    *
    * @return string
    */
-  public function resolve(EntityInterface $entity, RefinableCacheableDependencyInterface $metadata, $mode = NULL) {
+  public function resolve(EntityInterface $entity, $mode, RefinableCacheableDependencyInterface $metadata) {
     $mode = $mode ?? 'full';
     $builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
     $view = $builder->view($entity, $mode, $entity->language()->getId());

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
@@ -95,7 +95,7 @@ class EntityTranslations extends DataProducerPluginBase implements ContainerFact
    *
    * @return array|null
    */
-  public function resolve(EntityInterface $entity, ?bool $access , ?AccountInterface $accessUser, ?string $accessOperation) {
+  public function resolve(EntityInterface $entity, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation) {
     if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
       $languages = $entity->getTranslationLanguages();
 

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -141,7 +141,7 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
    *
    * @return \GraphQL\Deferred|null
    */
-  public function resolve(EntityInterface $entity, $field, $language = NULL, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+  public function resolve(EntityInterface $entity, $field, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context, $language = NULL) {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
+++ b/src/Plugin/GraphQL/DataProducer/Field/EntityReference.php
@@ -141,7 +141,7 @@ class EntityReference extends DataProducerPluginBase implements ContainerFactory
    *
    * @return \GraphQL\Deferred|null
    */
-  public function resolve(EntityInterface $entity, $field, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context, $language = NULL) {
+  public function resolve(EntityInterface $entity, $field, $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
     if (!$entity instanceof FieldableEntityInterface || !$entity->hasField($field)) {
       return NULL;
     }

--- a/src/Plugin/GraphQL/DataProducer/Menu/MenuTree/MenuTreeSubtree.php
+++ b/src/Plugin/GraphQL/DataProducer/Menu/MenuTree/MenuTreeSubtree.php
@@ -32,7 +32,7 @@ class MenuTreeSubtree extends DataProducerPluginBase {
    * @return mixed
    */
   public function resolve(MenuLinkTreeElement $element) {
-    return array_filter($element->subtree, function(MenuLinkTreeElement $item) {
+    return array_filter($element->subtree, function (MenuLinkTreeElement $item) {
       if ($item->link instanceof MenuLinkInterface) {
         return $item->link->isEnabled();
       }

--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
@@ -97,7 +97,7 @@ class RouteEntity extends DataProducerPluginBase implements ContainerFactoryPlug
   /**
    * {@inheritdoc}
    */
-  public function resolve($url, FieldContext $context, $language = NULL) {
+  public function resolve($url, $language, FieldContext $context) {
     if ($url instanceof Url) {
       list(, $type) = explode('.', $url->getRouteName());
       $parameters = $url->getRouteParameters();

--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
@@ -14,7 +14,6 @@ use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use GraphQL\Deferred;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-
 /**
  * @DataProducer(
  *   id = "route_entity",
@@ -98,7 +97,7 @@ class RouteEntity extends DataProducerPluginBase implements ContainerFactoryPlug
   /**
    * {@inheritdoc}
    */
-  public function resolve($url, $language = NULL, FieldContext $context) {
+  public function resolve($url, FieldContext $context, $language = NULL) {
     if ($url instanceof Url) {
       list(, $type) = explode('.', $url->getRouteName());
       $parameters = $url->getRouteParameters();

--- a/src/Plugin/GraphQL/DataProducer/TypedData/PropertyPath.php
+++ b/src/Plugin/GraphQL/DataProducer/TypedData/PropertyPath.php
@@ -40,12 +40,12 @@ class PropertyPath extends DataProducerPluginBase {
   /**
    * @param string $path
    * @param mixed $value
-   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    * @param string|null $type
+   * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    *
    * @return mixed
    */
-  public function resolve($path, $value, RefinableCacheableDependencyInterface $metadata, $type = NULL) {
+  public function resolve($path, $value, $type, RefinableCacheableDependencyInterface $metadata) {
     if (!($value instanceof TypedDataInterface) && !empty($type)) {
       $manager = $this->getTypedDataManager();
       $definition = $manager->createDataDefinition($type);

--- a/src/Plugin/GraphQL/DataProducer/TypedData/PropertyPath.php
+++ b/src/Plugin/GraphQL/DataProducer/TypedData/PropertyPath.php
@@ -40,12 +40,12 @@ class PropertyPath extends DataProducerPluginBase {
   /**
    * @param string $path
    * @param mixed $value
-   * @param string|null $type
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   * @param string|null $type
    *
    * @return mixed
    */
-  public function resolve($path, $value, $type = NULL, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve($path, $value, RefinableCacheableDependencyInterface $metadata, $type = NULL) {
     if (!($value instanceof TypedDataInterface) && !empty($type)) {
       $manager = $this->getTypedDataManager();
       $definition = $manager->createDataDefinition($type);

--- a/src/Plugin/MenuLink/Deriver/ExplorerMenuLinkDeriver.php
+++ b/src/Plugin/MenuLink/Deriver/ExplorerMenuLinkDeriver.php
@@ -6,7 +6,7 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\graphql\Entity\Server;
 
 /**
- * Class ExplorerMenuLinkDeriver
+ * Class ExplorerMenuLinkDeriver.
  *
  * @package Drupal\graphql\Plugin\MenuLink\Deriver
  *

--- a/src/Plugin/MenuLink/Deriver/VoyagerMenuLinkDeriver.php
+++ b/src/Plugin/MenuLink/Deriver/VoyagerMenuLinkDeriver.php
@@ -6,7 +6,7 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\graphql\Entity\Server;
 
 /**
- * Class VoyagerMenuLinkDeriver
+ * Class VoyagerMenuLinkDeriver.
  *
  * @package Drupal\graphql\Plugin\MenuLink\Deriver
  *

--- a/src/Plugin/SchemaExtensionPluginManager.php
+++ b/src/Plugin/SchemaExtensionPluginManager.php
@@ -7,7 +7,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 
 /**
- * Class SchemaExtensionPluginManager
+ * Class SchemaExtensionPluginManager.
  *
  * @package Drupal\graphql\Plugin
  *

--- a/src/Plugin/SchemaPluginManager.php
+++ b/src/Plugin/SchemaPluginManager.php
@@ -7,7 +7,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 
 /**
- * Class SchemaPluginManager
+ * Class SchemaPluginManager.
  *
  * @package Drupal\graphql\Plugin
  *

--- a/tests/src/Kernel/DataProducer/EntityTest.php
+++ b/tests/src/Kernel/DataProducer/EntityTest.php
@@ -21,7 +21,7 @@ use Drupal\entity_test\Entity\EntityTestBundle;
 class EntityTest extends GraphQLTestBase {
 
   /**
-   * @var NodeInterface
+   * @var \Drupal\node\NodeInterface
    */
   protected $node;
 

--- a/tests/src/Kernel/Framework/ResultCacheTest.php
+++ b/tests/src/Kernel/Framework/ResultCacheTest.php
@@ -330,7 +330,7 @@ GQL;
         ];
 
         $renderContext = new RenderContext();
-        $value = $renderer->executeInRenderContext($renderContext, function () use ($renderer, $el){
+        $value = $renderer->executeInRenderContext($renderContext, function () use ($renderer, $el) {
           return $renderer->render($el)->__toString();
         });
 
@@ -352,7 +352,7 @@ GQL;
         ];
 
         $renderContext = new RenderContext();
-        $value = $renderer->executeInRenderContext($renderContext, function () use ($renderer, $el){
+        $value = $renderer->executeInRenderContext($renderContext, function () use ($renderer, $el) {
           return $renderer->render($el)->__toString();
         });
 


### PR DESCRIPTION
exclude name="Drupal.Commenting.DocComment.SpacingAfter"
exclude name="Drupal.Commenting.DocComment.ShortFullStop"
exclude name="Drupal.Commenting.DocComment.ParamGroup"
exclude name="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace"
exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace"
exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace"
exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd"
exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"
exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"
exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma"
exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"
exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeBrace"