### PR TITLE
Move Drupal.Commenting.ClassComment.Missing exceptions on a file basis

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,12 +7,15 @@
 
   <rule ref="Drupal">
     <!-- TODO: those rules are disabled for now until we fix the coding standards for them. -->
-    <exclude name="Drupal.Commenting.ClassComment.Missing"/>
     <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingParamType"/>
     <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
     <exclude name="Drupal.Commenting.FunctionComment.InvalidNoReturn"/>
+  </rule>
+
+  <rule ref="Drupal.Commenting.ClassComment.Missing">
+    <exclude-pattern>tests/src/Kernel/GraphQLTestBase.php</exclude-pattern>
   </rule>
 
 </ruleset>


### PR DESCRIPTION
Example for @Dylan203 how to move our general exclusions to file based exclusions, so that we only exclude existing old code from checking.