### PR TITLE
tests(phpstan): Fix phpstan problem with finding a phpunit file

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ includes:
 	- ../../vendor/mglaman/phpstan-drupal/extension.neon
 
 parameters:
+	# PHPStan cannot find this file automatically.
+	scanFiles:
+		- ../../core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php
 	level: 1
 	customRulesetUsed: true
 	paths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,9 +3,9 @@ includes:
 	- ../../vendor/mglaman/phpstan-drupal/extension.neon
 
 parameters:
-	# PHPStan cannot find this file automatically.
-	scanFiles:
-		- ../../core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php
+	# PHPStan cannot find files in this test directory automatically.
+	scanDirectories:
+		- ../../core/tests/Drupal/Tests
 	level: 1
 	customRulesetUsed: true
 	paths:


### PR DESCRIPTION
Fixes "Reflection error: Drupal\Tests\PhpunitCompatibilityTrait not found. 💡 Learn more at https://phpstan.org/user-guide/discovering-symbols"