### PR TITLE
fix(files): Fix lock release handling when the file upload does not validate

### DIFF
--- a/src/GraphQL/Utility/FileUpload.php
+++ b/src/GraphQL/Utility/FileUpload.php
@@ -223,46 +223,51 @@ class FileUpload {
       return $response;
     }
 
-    // Begin building file entity.
-    /** @var \Drupal\file\FileInterface $file */
-    $file = $this->fileStorage->create([]);
-    $file->setOwnerId($this->currentUser->id());
-    $file->setFilename($prepared_filename);
-    $file->setMimeType($this->mimeTypeGuesser->guess($prepared_filename));
-    $file->setFileUri($file_uri);
-    // Set the size. This is done in File::preSave() but we validate the file
-    // before it is saved.
-    $file->setSize(@filesize($temp_file_path));
-
-    // Validate the file entity against entity-level validation and field-level
-    // validators.
-    if (!$this->validate($file, $validators, $response)) {
-      return $response;
-    }
-
-    // Move the file to the correct location after validation. Use
-    // FileSystemInterface::EXISTS_ERROR as the file location has already been
-    // determined above in FileSystem::getDestinationFilename().
     try {
-      $this->fileSystem->move($temp_file_path, $file_uri, FileSystemInterface::EXISTS_ERROR);
-    }
-    catch (FileException $e) {
-      $response->addViolation($this->t('Unknown error while uploading the file "@file".', [
-        '@file' => $uploaded_file->getClientOriginalName(),
-      ]));
-      $this->logger->error('Unable to move file from "@file" to "@destination".', [
-        '@file' => $uploaded_file->getRealPath(),
-        '@destination' => $file->getFileUri(),
-      ]);
+      // Begin building file entity.
+      /** @var \Drupal\file\FileInterface $file */
+      $file = $this->fileStorage->create([]);
+      $file->setOwnerId($this->currentUser->id());
+      $file->setFilename($prepared_filename);
+      $file->setMimeType($this->mimeTypeGuesser->guess($prepared_filename));
+      $file->setFileUri($file_uri);
+      // Set the size. This is done in File::preSave() but we validate the file
+      // before it is saved.
+      $file->setSize(@filesize($temp_file_path));
+
+      // Validate the file entity against entity-level validation and field-level
+      // validators.
+      if (!$this->validate($file, $validators, $response)) {
+        return $response;
+      }
+
+      // Move the file to the correct location after validation. Use
+      // FileSystemInterface::EXISTS_ERROR as the file location has already been
+      // determined above in FileSystem::getDestinationFilename().
+      try {
+        $this->fileSystem->move($temp_file_path, $file_uri, FileSystemInterface::EXISTS_ERROR);
+      }
+      catch (FileException $e) {
+        $response->addViolation($this->t('Unknown error while uploading the file "@file".', [
+          '@file' => $uploaded_file->getClientOriginalName(),
+        ]));
+        $this->logger->error('Unable to move file from "@file" to "@destination".', [
+          '@file' => $uploaded_file->getRealPath(),
+          '@destination' => $file->getFileUri(),
+        ]);
+        return $response;
+      }
+
+      $file->save();
+
+      $response->setFileEntity($file);
       return $response;
     }
-
-    $file->save();
-
-    $this->lock->release($lock_id);
-
-    $response->setFileEntity($file);
-    return $response;
+    finally {
+      // This will always be executed before any return statement or exception
+      // in the try {} block.
+      $this->lock->release($lock_id);
+    }
   }
 
   /**

--- a/src/GraphQL/Utility/FileUpload.php
+++ b/src/GraphQL/Utility/FileUpload.php
@@ -235,8 +235,8 @@ class FileUpload {
       // before it is saved.
       $file->setSize(@filesize($temp_file_path));
 
-      // Validate the file entity against entity-level validation and field-level
-      // validators.
+      // Validate the file entity against entity-level validation and
+      // field-level validators.
       if (!$this->validate($file, $validators, $response)) {
         return $response;
       }


### PR DESCRIPTION
Follow-up to #1115 . We need to release the lock correctly when file validation fails.

I found the `finally` keyword in PHP which does exactly what we want, yay! https://www.php.net/manual/en/language.exceptions.php

Same bug in FileUploadResource in Drupal core: https://www.drupal.org/project/drupal/issues/3184974