### PR TITLE
Make ImageDerivative configurable to return additional properties

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
@@ -26,6 +26,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *     ),
  *     "style" = @ContextDefinition("string",
  *       label = @Translation("Image style")
+ *     ),
+ *     "additional_properties" = @ContextDefinition("list",
+ *       label = @Translation("Additional properties")
  *     )
  *   }
  * )
@@ -85,7 +88,7 @@ class ImageDerivative extends DataProducerPluginBase implements ContainerFactory
    *
    * @return mixed
    */
-  public function resolve(FileInterface $entity = NULL, $style, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve(FileInterface $entity = NULL, $style, array $additional_properties = [], RefinableCacheableDependencyInterface $metadata) {
     // Return if we dont have an entity.
     if (!$entity) {
       return NULL;
@@ -129,11 +132,18 @@ class ImageDerivative extends DataProducerPluginBase implements ContainerFactory
         $metadata->addCacheableDependency($context->pop());
       }
 
-      return [
+      $return = [
+        'id' => $entity->id(),
         'url' => $url,
         'width' => $dimensions['width'],
         'height' => $dimensions['height'],
       ];
+
+      foreach($additional_properties as $property) {
+        $return[$property] = $entity->get($property)->value;
+      }
+
+      return $return;
     }
 
     return NULL;


### PR DESCRIPTION
Resolves #1120 

### Usage
Use `ImageDerivative` to extract extra properties from `File` entities such as `filename`, `uri`, `filemime`, etc. See Drupal's File entity for full list of `field_name`'s that can be used.

> Make sure you update your schema definition to include the additional properties you use from `ImageDerivative`.

### Example
```php
    // MySchemaExtension.php

    ...

    $registry->addFieldResolver('MyResolveType', 'images',
      $builder->compose(
        $builder->produce('entity_reference')
          ->map('entity', $builder->fromParent())
          ->map('field', $builder->fromValue('field_images')),
        $builder->map(
          $builder->produce('image_derivative')
            ->map('entity', $builder->fromParent())
            ->map('style', $builder->fromValue('submission_media_carousel'))
            ->map('additional_properties', $builder->fromValue(['filename', 'filemime']))
        )
      )
    );
```

```
// my_graphql.graphqls

...

type Image {
  id: Int!
  url: String!
  width: Int
  height: Int
  filename: String!
  filemime: String!
}
```

