### PR TITLE
fix(graphql_core): fix drush site-install

### DIFF
--- a/modules/graphql_core/graphql_core.info.yml
+++ b/modules/graphql_core/graphql_core.info.yml
@@ -5,3 +5,4 @@ package: GraphQL
 core_version_requirement: ^8.8 || ^9
 dependencies:
   - graphql:graphql
+  - path_alias


### PR DESCRIPTION
I've got the following error during `drush site-install --existing-config` on a project having graphql_core enabled:
```
TypeError: Argument 4 passed to Drupal\graphql_core\Plugin\GraphQL\Fields\Routing\InternalUrl\Alias::__construct() must implement interface Drupal\path_alias\AliasManagerInterface, instance of Drupal\Core\Path\AliasManager given
```

Drupal has two `path.alias_manager` services:
- `Drupal\Core\Path\AliasManager` in core, deprecated
- `Drupal\path_alias\AliasManager` in path_alias module

The path_alias module is required, but this does not mean it will be installed before graphql_core. Adding a dependency to the module helps Drupal to install modules in the right order.