### PR TITLE
fix(file-upload): Catch leaked cacheable metadata when using token service to prevent fatal error.

### DIFF
--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -153,6 +153,7 @@ services:
       - '@token'
       - '@lock'
       - '@config.factory'
+      - '@renderer'
 
   plugin.manager.graphql.persisted_query:
     class: Drupal\graphql\Plugin\PersistedQueryPluginManager

--- a/tests/src/Kernel/Framework/UploadFileServiceTest.php
+++ b/tests/src/Kernel/Framework/UploadFileServiceTest.php
@@ -196,7 +196,8 @@ class UploadFileServiceTest extends GraphQLTestBase {
       \Drupal::service('logger.channel.graphql'),
       \Drupal::service('token'),
       $lock->reveal(),
-      \Drupal::service('config.factory')
+      \Drupal::service('config.factory'),
+      \Drupal::service('renderer')
     );
 
     // Create a file with 4 bytes.


### PR DESCRIPTION
Currently we don't catch cacheable metadata when replacing tokens with service in destination path. This produces the following error:
```
LogicException: The controller result claims to be providing relevant cache metadata, but leaked metadata was detected. Please ensure you are not rendering content too early.
```

PR fixes that.