### PR TITLE
Add workaround for BigInt field type support as string

### DIFF
--- a/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
+++ b/modules/graphql_core/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
@@ -42,6 +42,13 @@ class EntityFieldDeriver extends EntityFieldDeriverBase {
     if (count($propertyDefinitions) === 1) {
       $propertyDefinition = reset($propertyDefinitions);
       $derivative['type'] = $propertyDefinition->getDataType();
+
+      // Workaround for BigInt field types (integer with size = big)
+      // Treat as String instead of Integer in GraphQL, because of lack support for 64 bit integers
+      // More info: https://github.com/graphql/graphql-spec/issues/73
+      if($propertyDefinition->getDataType() == 'integer' && $itemDefinition->getSetting('size') == 'big') {
+        $derivative['type'] = 'string';
+      }
       $derivative['property'] = key($propertyDefinitions);
     }
     else {


### PR DESCRIPTION
Here is workaround for fix errors with BigInt Drupal field types (Integer with size = big).
Now those fields are represented as 32-bit integer in GraphQL, and throw the error, when value is larger than 32-bit, with inserting `null` in result.
This workaround is replacing Integer GraphQL field type to String for those field types, to fix described problem.
Closes #1130 