### PR TITLE
Use array values instead of order.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
@@ -46,7 +46,7 @@ abstract class DataProducerPluginBase extends ContextAwarePluginBase implements 
     $context = $this->getContextValues();
     return call_user_func_array(
       [$this, 'resolve'],
-      array_merge($context, [$field])
+      array_values(array_merge($context, [$field]))
     );
   }
 


### PR DESCRIPTION
Use the array values instead of the order inside the call_user_func_array.

Closes #1147