### PR TITLE
Implement GraphQL Server Validations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0+",
   "require": {
     "php": ">=7.2",
-    "webonyx/graphql-php": "^14.3.0"
+    "webonyx/graphql-php": "^14.5.0"
   },
   "minimum-stability": "dev"
 }

--- a/graphql.links.task.yml
+++ b/graphql.links.task.yml
@@ -24,6 +24,11 @@ graphql.voyager:
   base_route: entity.graphql_server.edit_form
   title: Voyager
 
+graphql.validate:
+  route_name: graphql.validate
+  base_route: entity.graphql_server.edit_form
+  title: Validate
+
 entity.graphql_server.collection:
   title: Servers
   route_name: entity.graphql_server.collection

--- a/graphql.routing.yml
+++ b/graphql.routing.yml
@@ -64,6 +64,20 @@ graphql.voyager:
       graphql_server:
         type: entity:graphql_server
 
+graphql.validate:
+  path: '/admin/config/graphql/servers/manage/{graphql_server}/validate'
+  defaults:
+    _controller: '\Drupal\graphql\Controller\ValidationController::report'
+    _title: 'Validate GraphQL Server'
+  requirements:
+    _permission: 'administer graphql configuration'
+  options:
+    _admin_route: TRUE
+    parameters:
+      graphql_server:
+        type: entity:graphql_server
+
+
 entity.graphql_server.delete_form:
   path: '/admin/config/graphql/servers/manage/{graphql_server}/delete'
   defaults:

--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -89,6 +89,11 @@ services:
   graphql.introspection:
     class: Drupal\graphql\GraphQL\Utility\Introspection
 
+  # Validator service.
+  graphql.validator:
+    class: Drupal\graphql\GraphQL\Validator
+    arguments: ['@plugin.manager.graphql.schema', '@logger.channel.graphql']
+
   # Reset the current language during sub-requests.
   graphql.subrequest_subscriber:
     class: Drupal\graphql\EventSubscriber\SubrequestSubscriber

--- a/src/Controller/ValidationController.php
+++ b/src/Controller/ValidationController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\graphql\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\graphql\Entity\ServerInterface;
+use Drupal\graphql\GraphQL\ValidatorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for the GraphiQL resolver validation.
+ */
+class ValidationController implements ContainerInjectionInterface {
+  use StringTranslationTrait;
+
+  /**
+   * The schema plugin manager.
+   *
+   * @var \Drupal\graphql\GraphQL\ValidatorInterface
+   */
+  protected ValidatorInterface $validator;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('graphql.validator'),
+    );
+  }
+
+  /**
+   * ValidateResolverController constructor.
+   *
+   * @param \Drupal\graphql\GraphQL\ValidatorInterface $validator
+   *   The GraphQL validator.
+   */
+  public function __construct(ValidatorInterface $validator) {
+    $this->validator = $validator;
+  }
+
+  /**
+   * Controller for the GraphiQL query builder IDE.
+   *
+   * @param \Drupal\graphql\Entity\ServerInterface $graphql_server
+   *   The GraphQL server entity.
+   *
+   * @return array
+   *   The render array.
+   */
+  public function report(ServerInterface $graphql_server) {
+    $build = [
+      'validation' => [
+        '#type' => 'table',
+        '#caption' => $this->t("Validation errors"),
+        '#header' => [$this->t('Type'), $this->t('Field'), $this->t('Message')],
+        '#empty' => $this->t("No validation errors."),
+      ],
+      'orphaned' => [
+        '#type' => 'table',
+        '#caption' => $this->t("Resolvers without schema"),
+        '#header' => [$this->t('Type'), $this->t('Fields')],
+        '#empty' => $this->t("No orphaned resolvers."),
+      ],
+      'missing' => [
+        '#type' => 'table',
+        '#caption' => $this->t("Fields without resolvers"),
+        '#header' => [$this->t('Type'), $this->t('Fields')],
+        '#empty' => $this->t("No missing resolvers."),
+      ],
+    ];
+
+    foreach ($this->validator->validateSchema($graphql_server) as $error) {
+      $type = '';
+      if (isset($error->nodes[1]) && property_exists($error->nodes[1], 'name')) {
+        $type = $error->nodes[1]->name->value;
+      }
+      $field = '';
+      if (isset($error->nodes[0]) && property_exists($error->nodes[1], 'name')) {
+        $field = $error->nodes[0]->name->value;
+      }
+
+      $build['validation'][] = [
+        'type' => ['#plain_text' => $type],
+        'field' => ['#plain_text' => $field],
+        'message' => ['#plain_text' => $error->getMessage()],
+      ];
+    }
+
+    // TODO: Ability to configure ignores here.
+    $metrics = [
+      'orphaned' => $this->validator->getOrphanedResolvers($graphql_server),
+      'missing' => $this->validator->getMissingResolvers($graphql_server),
+    ];
+
+    foreach ($metrics as $metric_type => $data) {
+      foreach ($data as $type => $fields) {
+        $build[$metric_type][$type] = [
+          'type' => ['#plain_text' => $type],
+          'fields' => [
+            '#theme' => 'item_list',
+            '#items' => $fields,
+          ],
+        ];
+      }
+    }
+
+    return $build;
+  }
+
+}

--- a/src/Controller/ValidationController.php
+++ b/src/Controller/ValidationController.php
@@ -26,7 +26,7 @@ class ValidationController implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) : self {
     return new static(
-      $container->get('graphql.validator'),
+      $container->get('graphql.validator')
     );
   }
 

--- a/src/Controller/ValidationController.php
+++ b/src/Controller/ValidationController.php
@@ -88,7 +88,7 @@ class ValidationController implements ContainerInjectionInterface {
       ];
     }
 
-    // TODO: Ability to configure ignores here.
+    // @todo Ability to configure ignores here.
     $metrics = [
       'orphaned' => $this->validator->getOrphanedResolvers($graphql_server),
       'missing' => $this->validator->getMissingResolvers($graphql_server),

--- a/src/Controller/ValidationController.php
+++ b/src/Controller/ValidationController.php
@@ -19,7 +19,7 @@ class ValidationController implements ContainerInjectionInterface {
    *
    * @var \Drupal\graphql\GraphQL\ValidatorInterface
    */
-  protected ValidatorInterface $validator;
+  protected $validator;
 
   /**
    * {@inheritdoc}

--- a/src/Controller/ValidationController.php
+++ b/src/Controller/ValidationController.php
@@ -24,7 +24,7 @@ class ValidationController implements ContainerInjectionInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container) : self {
     return new static(
       $container->get('graphql.validator'),
     );
@@ -77,7 +77,7 @@ class ValidationController implements ContainerInjectionInterface {
         $type = $error->nodes[1]->name->value;
       }
       $field = '';
-      if (isset($error->nodes[0]) && property_exists($error->nodes[1], 'name')) {
+      if (isset($error->nodes[0]) && property_exists($error->nodes[0], 'name')) {
         $field = $error->nodes[0]->name->value;
       }
 

--- a/src/GraphQL/ResolverRegistry.php
+++ b/src/GraphQL/ResolverRegistry.php
@@ -142,7 +142,7 @@ class ResolverRegistry implements ResolverRegistryInterface {
   /**
    * {@inheritdoc}
    */
-  public function getFieldResolverWithInheritance(Type $type, $fieldName) : ?ResolverInterface {
+  public function getFieldResolverWithInheritance(Type $type, string $fieldName) : ?ResolverInterface {
     if ($resolver = $this->getFieldResolver($type->name, $fieldName)) {
       return $resolver;
     }

--- a/src/GraphQL/ResolverRegistry.php
+++ b/src/GraphQL/ResolverRegistry.php
@@ -119,6 +119,13 @@ class ResolverRegistry implements ResolverRegistryInterface {
   /**
    * {@inheritdoc}
    */
+  public function getAllFieldResolvers() : array {
+    return $this->fieldResolvers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addTypeResolver($abstract, callable $resolver) {
     $this->typeResolvers[$abstract] = $resolver;
     return $this;

--- a/src/GraphQL/ResolverRegistry.php
+++ b/src/GraphQL/ResolverRegistry.php
@@ -118,7 +118,12 @@ class ResolverRegistry implements ResolverRegistryInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Return all field resolvers in the registry.
+   *
+   * @return callable[]
+   *   A nested list of callables, keyed by type and field name.
+   *
+   * @todo This should be added to ResolverRegistryInterface in 5.0.0.
    */
   public function getAllFieldResolvers() : array {
     return $this->fieldResolvers;
@@ -140,7 +145,24 @@ class ResolverRegistry implements ResolverRegistryInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Get a field resolver for the type or any of the interfaces it implements.
+   *
+   * This allows common functionality (such as for Edge's or Connections) to be
+   * implemented for an interface and re-used on any concrete type that extends
+   * it.
+   *
+   * This should be used instead of `getFieldResolver` unless you're certain you
+   * want the resolver only for the specific type.
+   *
+   * @param \GraphQL\Type\Definition\Type $type
+   *   The type to find a resolver for.
+   * @param string $fieldName
+   *   The name of the field to find a resolver for.
+   *
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null
+   *   The defined resolver for the field or NULL if none exists.
+   *
+   * @todo This should be added to ResolverRegistryInterface in 5.0.0.
    */
   public function getFieldResolverWithInheritance(Type $type, string $fieldName) : ?ResolverInterface {
     if ($resolver = $this->getFieldResolver($type->name, $fieldName)) {

--- a/src/GraphQL/ResolverRegistryInterface.php
+++ b/src/GraphQL/ResolverRegistryInterface.php
@@ -6,6 +6,7 @@ use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
 
 /**
  * Defines a registry to resolve any field in the GraphQL schema tree.
@@ -50,6 +51,9 @@ interface ResolverRegistryInterface {
   /**
    * Return the field resolver for a given type and field name.
    *
+   * Most code will probably want to use `getFieldResolverWithInheritance`
+   * instead.
+   *
    * @param string $type
    * @param string $field
    *
@@ -85,5 +89,25 @@ interface ResolverRegistryInterface {
    * @return callable|null
    */
   public function getTypeResolver($type);
+
+  /**
+   * Get a field resolver for the type or any of the interfaces it implements.
+   *
+   * This allows common functionality (such as for Edge's or Connections) to be
+   * implemented for an interface and re-used on any concrete type that extends
+   * it.
+   *
+   * This should be used instead of `getFieldResolver` unless you're certain you
+   * want the resolver only for the specific type.
+   *
+   * @param \GraphQL\Type\Definition\Type $type
+   *   The type to find a resolver for.
+   * @param string $fieldName
+   *   The name of the field to find a resolver for.
+   *
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null
+   *   The defined resolver for the field or NULL if none exists.
+   */
+  public function getFieldResolverWithInheritance(Type $type, string $fieldName) : ?ResolverInterface;
 
 }

--- a/src/GraphQL/ResolverRegistryInterface.php
+++ b/src/GraphQL/ResolverRegistryInterface.php
@@ -6,7 +6,6 @@ use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Type\Definition\Type;
 
 /**
  * Defines a registry to resolve any field in the GraphQL schema tree.
@@ -51,23 +50,12 @@ interface ResolverRegistryInterface {
   /**
    * Return the field resolver for a given type and field name.
    *
-   * Most code will probably want to use `getFieldResolverWithInheritance`
-   * instead.
-   *
    * @param string $type
    * @param string $field
    *
    * @return callable|null
    */
   public function getFieldResolver($type, $field);
-
-  /**
-   * Return all field resolvers in the registry.
-   *
-   * @return callable[]
-   *   A nested list of callables, keyed by type and field name.
-   */
-  public function getAllFieldResolvers() : array;
 
   /**
    * Add a type resolver.
@@ -89,25 +77,5 @@ interface ResolverRegistryInterface {
    * @return callable|null
    */
   public function getTypeResolver($type);
-
-  /**
-   * Get a field resolver for the type or any of the interfaces it implements.
-   *
-   * This allows common functionality (such as for Edge's or Connections) to be
-   * implemented for an interface and re-used on any concrete type that extends
-   * it.
-   *
-   * This should be used instead of `getFieldResolver` unless you're certain you
-   * want the resolver only for the specific type.
-   *
-   * @param \GraphQL\Type\Definition\Type $type
-   *   The type to find a resolver for.
-   * @param string $fieldName
-   *   The name of the field to find a resolver for.
-   *
-   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null
-   *   The defined resolver for the field or NULL if none exists.
-   */
-  public function getFieldResolverWithInheritance(Type $type, string $fieldName) : ?ResolverInterface;
 
 }

--- a/src/GraphQL/ResolverRegistryInterface.php
+++ b/src/GraphQL/ResolverRegistryInterface.php
@@ -58,6 +58,14 @@ interface ResolverRegistryInterface {
   public function getFieldResolver($type, $field);
 
   /**
+   * Return all field resolvers in the registry.
+   *
+   * @return callable[]
+   *   A nested list of callables, keyed by type and field name.
+   */
+  public function getAllFieldResolvers() : array;
+
+  /**
    * Add a type resolver.
    *
    * @todo Type resolvers should also get their own interface.

--- a/src/GraphQL/Validator.php
+++ b/src/GraphQL/Validator.php
@@ -46,7 +46,13 @@ class Validator implements ValidatorInterface {
    */
   public function validateSchema(ServerInterface $server): array {
     $plugin = $this->getSchemaPlugin($server);
-    return $plugin->getSchema($plugin->getResolverRegistry())->validate();
+    try {
+      return $plugin->getSchema($plugin->getResolverRegistry())->validate();
+    }
+    // Catch errors that may be thrown during schema retrieval.
+    catch (Error $e) {
+      return [$e];
+    }
   }
 
   /**
@@ -55,7 +61,14 @@ class Validator implements ValidatorInterface {
   public function getMissingResolvers(ServerInterface $server, array $ignore_types = []) : array {
     $plugin = $this->getSchemaPlugin($server);
     $resolver_registry = $plugin->getResolverRegistry();
-    $schema = $plugin->getSchema($resolver_registry);
+
+    try {
+      $schema = $plugin->getSchema($resolver_registry);
+    }
+    // In case the schema can't even be loaded we can't report anything.
+    catch (Error $e) {
+      return [];
+    }
 
     $missing_resolvers = [];
     foreach ($schema->getTypeMap() as $type) {
@@ -95,7 +108,14 @@ class Validator implements ValidatorInterface {
   public function getOrphanedResolvers(ServerInterface $server, array $ignore_types = []) : array {
     $plugin = $this->getSchemaPlugin($server);
     $resolver_registry = $plugin->getResolverRegistry();
-    $schema = $plugin->getSchema($resolver_registry);
+
+    try {
+      $schema = $plugin->getSchema($resolver_registry);
+    }
+    // In case the schema can't even be loaded we can't report anything.
+    catch (Error $e) {
+      return [];
+    }
 
     if (!method_exists($resolver_registry, "getAllFieldResolvers")) {
       $this->logger->warning(

--- a/src/GraphQL/Validator.php
+++ b/src/GraphQL/Validator.php
@@ -62,6 +62,17 @@ class Validator implements ValidatorInterface {
     $plugin = $this->getSchemaPlugin($server);
     $resolver_registry = $plugin->getResolverRegistry();
 
+    if (!method_exists($resolver_registry, "getFieldResolverWithInheritance")) {
+      $this->logger->warning(
+        "Could not get missing resolvers for @server_name as its registry class (@klass) does not implement getFieldResolverWithInheritance.",
+        [
+          '@server_name' => $server->id(),
+          '@klass' => get_class($resolver_registry),
+        ]
+      );
+      return [];
+    }
+
     try {
       $schema = $plugin->getSchema($resolver_registry);
     }
@@ -119,7 +130,7 @@ class Validator implements ValidatorInterface {
 
     if (!method_exists($resolver_registry, "getAllFieldResolvers")) {
       $this->logger->warning(
-        "Could not get orphaned resolvers for @server_name as it's registry class (@klass) does not implement getAllFieldResolvers.",
+        "Could not get orphaned resolvers for @server_name as its registry class (@klass) does not implement getAllFieldResolvers.",
         [
           '@server_name' => $server->id(),
           '@klass' => get_class($resolver_registry),

--- a/src/GraphQL/Validator.php
+++ b/src/GraphQL/Validator.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Drupal\graphql\GraphQL;
+
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\graphql\Entity\ServerInterface;
+use Drupal\graphql\Plugin\SchemaPluginInterface;
+use Drupal\graphql\Plugin\SchemaPluginManager;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * GraphQL validation service.
+ */
+class Validator implements ValidatorInterface {
+
+  /**
+   * The schema plugin manager.
+   *
+   * @var \Drupal\graphql\Plugin\SchemaPluginManager
+   */
+  protected $pluginManager;
+
+  /**
+   * GraphQL logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * ValidateResolverController constructor.
+   *
+   * @param \Drupal\graphql\Plugin\SchemaPluginManager $pluginManager
+   *   The schema plugin manager.
+   */
+  public function __construct(SchemaPluginManager $pluginManager) {
+    $this->pluginManager = $pluginManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateSchema(ServerInterface $server): array {
+    $plugin = $this->getSchemaPlugin($server);
+    return $plugin->getSchema($plugin->getResolverRegistry())->validate();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMissingResolvers(ServerInterface $server, array $ignore_types = []) : array {
+    $plugin = $this->getSchemaPlugin($server);
+    $resolver_registry = $plugin->getResolverRegistry();
+    $schema = $plugin->getSchema($resolver_registry);
+
+    $missing_resolvers = [];
+    foreach ($schema->getTypeMap() as $type) {
+      // We only care about concrete fieldable types. Resolvers may be defined
+      // for interfaces to be available for all implementing types, but only the
+      // actual resolved types need resolvers for their fields.
+      if (!$type instanceof ObjectType) {
+        continue;
+      }
+
+      if (in_array($type->name, $ignore_types, TRUE)) {
+        continue;
+      }
+
+      foreach ($type->getFields() as $field) {
+        if (!$this->hasResolver($resolver_registry, $type, $field)) {
+          if (!isset($missing_resolvers[$type->name])) {
+            $missing_resolvers[$type->name] = [];
+          }
+          $missing_resolvers[$type->name][] = $field->name;
+        }
+      }
+    }
+
+    return $missing_resolvers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOrphanedResolvers(ServerInterface $server, array $ignore_types = []) : array {
+    $plugin = $this->getSchemaPlugin($server);
+    $resolver_registry = $plugin->getResolverRegistry();
+    $schema = $plugin->getSchema($resolver_registry);
+
+    if (!method_exists($resolver_registry, "getAllFieldResolvers")) {
+      $this->logger->warning(
+        "Could not get orphaned resolvers for @server_name as it's registry class (@klass) does not implement getAllFieldResolvers.",
+        [
+          '@server_name' => $server->id(),
+          '@klass' => get_class($resolver_registry),
+        ]
+      );
+      return [];
+    }
+
+    $orphaned_resolvers = [];
+    foreach ($resolver_registry->getAllFieldResolvers() as $type_name => $fields) {
+      $type = $schema->getType($type_name);
+      // If the type can't have any fields then our resolvers don't make sense.
+      if (!$type instanceof InterfaceType &&
+        !$type instanceof ObjectType &&
+        !$type instanceof InputObjectType) {
+        $orphaned_resolvers[$type_name] = $fields;
+        continue;
+      }
+
+      if (in_array($type->name, $ignore_types, TRUE)) {
+        continue;
+      }
+
+      foreach ($fields as $field_name => $resolver) {
+        try {
+          $type->getField($field_name);
+        }
+        catch (InvariantViolation $_) {
+          if (!isset($orphaned_resolvers[$type_name])) {
+            $orphaned_resolvers[$type_name] = [];
+          }
+          $orphaned_resolvers[$type_name][] = $field_name;
+        }
+      }
+    }
+
+    return $orphaned_resolvers;
+  }
+
+  /**
+   * Try to find a resolver for the type or one of its implemented interfaces.
+   *
+   * @param \Drupal\graphql\GraphQL\ResolverRegistryInterface $registry
+   *   The registry to find a resolver in.
+   * @param \GraphQL\Type\Definition\Type $type
+   *   The type definition to find a resolver for.
+   * @param \GraphQL\Type\Definition\FieldDefinition $field
+   *   The field on the type to find a resolver for.
+   *
+   * @return bool
+   *   Whether the registry has a registered resolver.
+   */
+  protected function hasResolver(ResolverRegistryInterface $registry, Type $type, FieldDefinition $field) : bool {
+    // Skip hidden/internal/introspection types since they're handled by GraphQL
+    // itself.
+    if (strpos($type->name, "__") === 0) {
+      return TRUE;
+    }
+
+    if ($registry->getFieldResolver($type->name, $field->name) !== NULL) {
+      return TRUE;
+    }
+
+    // If the type doesn't support interfaces we're done.
+    if (!method_exists($type, "getInterfaces")) {
+      return FALSE;
+    }
+
+    /** @var \GraphQL\Type\Definition\Type $interface */
+    foreach ($type->getInterfaces() as $interface) {
+      if ($this->hasResolver($registry, $interface, $field)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Get the schema plugin for a GraphQL server.
+   *
+   * @param \Drupal\graphql\Entity\ServerInterface $server
+   *   The GraphQL server.
+   *
+   * @return \Drupal\graphql\Plugin\SchemaPluginInterface
+   *   A schema plugin interface.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   *   Thrown when no schema plugin is defined for the server.
+   */
+  private function getSchemaPlugin(ServerInterface $server) : SchemaPluginInterface {
+    $schema_name = $server->get('schema');
+    /** @var \Drupal\graphql\Plugin\SchemaPluginInterface $plugin */
+    $plugin = $this->pluginManager->createInstance($schema_name);
+    if ($plugin instanceof ConfigurableInterface && $config = $server->get('schema_configuration')) {
+      $plugin->setConfiguration($config[$schema_name] ?? []);
+    }
+
+    return $plugin;
+  }
+
+}

--- a/src/GraphQL/ValidatorInterface.php
+++ b/src/GraphQL/ValidatorInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\graphql\GraphQL;
+
+use Drupal\graphql\Entity\ServerInterface;
+
+/**
+ * Validation service interface for Drupal GraphQL servers.
+ */
+interface ValidatorInterface {
+
+  /**
+   * Validates the schema of the server.
+   *
+   * @param \Drupal\graphql\Entity\ServerInterface $server
+   *   The server to validate.
+   *
+   * @return \GraphQL\Error\Error[]
+   *   An array of validation errors.
+   */
+  public function validateSchema(ServerInterface $server) : array;
+
+  /**
+   * Get a list of missing resolvers.
+   *
+   * A resolver is considered missing if a field definition exists in the SDL
+   * (.graphqls) files for this server but the type or any of its implemented
+   * interfaces do not have a registered resolver in the server's resolver
+   * registry for the field.
+   *
+   * @param \Drupal\graphql\Entity\ServerInterface $server
+   *   The server to validate.
+   * @param array $ignore_types
+   *   Any types to ignore during validation.
+   *
+   * @return array
+   *   An array keyed by type containing arrays of field names.
+   */
+  public function getMissingResolvers(ServerInterface $server, array $ignore_types = []) : array;
+
+  /**
+   * Get a list of orphaned resolvers.
+   *
+   * A resolver is considered orphaned if it's defined in the resolver registry
+   * for the server but the field does not occur in any SDL (.graphqls) files.
+   *
+   * @param \Drupal\graphql\Entity\ServerInterface $server
+   *   The server to validate.
+   * @param array $ignore_types
+   *   Any types to ignore during validation.
+   *
+   * @return array
+   *   An array keyed by type containing arrays of field names.
+   */
+  public function getOrphanedResolvers(ServerInterface $server, array $ignore_types = []) : array;
+
+}

--- a/tests/src/Kernel/ResolverRegistryTest.php
+++ b/tests/src/Kernel/ResolverRegistryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel;
+
+use Drupal\graphql\GraphQL\ResolverRegistry;
+
+/**
+ * Tests that the resolver registry behaves correctly.
+ *
+ * @coversDefaultClass \Drupal\graphql\GraphQL\ResolverRegistry
+ *
+ * @group graphql
+ */
+class ResolverRegistryTest extends GraphQLTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $schema = <<<GQL
+      type Query {
+        transportation: Vehicle
+      }
+
+      interface Vehicle {
+        model: String
+      }
+
+      interface Car implements Vehicle {
+        model: String
+      }
+
+      type Tesla implements Car {
+        model: String
+      }
+GQL;
+
+    $this->setUpSchema($schema);
+
+    // Our mocking trait sets up the ResolverRegistry that we're interested in
+    // testing for us. This assertion guards against the mock implementation
+    // invalidating that and this test becoming useless.
+    self::assertInstanceOf(ResolverRegistry::class, $this->registry);
+  }
+
+  /**
+   * @covers ::getAllFieldResolvers
+   */
+  public function testGetAllFieldResolvers() : void {
+    $transportation_resolver = $this->builder->fromValue('Ford Model T');
+    $this->mockResolver('Query', 'transportation', $transportation_resolver);
+    $car_resolver = $this->builder->fromParent();
+    $this->mockResolver('Car', 'model', $car_resolver);
+    $tesla_resolver = $this->builder->fromValue('Tesla');
+    $this->mockResolver('Tesla', 'model', $tesla_resolver);
+
+    self::assertEquals(
+      [
+        'Query' => ['transportation' => $transportation_resolver],
+        'Car' => ['model' => $car_resolver],
+        'Tesla' => ['model' => $tesla_resolver],
+      ],
+      $this->registry->getAllFieldResolvers()
+    );
+
+  }
+
+  /**
+   * @covers ::getFieldResolverWithInheritance
+   */
+  public function testGetFieldResolverWithInheritanceTraversesSingleInheritance() : void {
+    $expected_resolver = $this->builder->fromValue('Car');
+    $this->mockResolver('Car', 'model', $expected_resolver);
+
+    $returned_resolver = $this->registry->getFieldResolverWithInheritance(
+      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      'model'
+    );
+
+    self::assertEquals(
+      $expected_resolver,
+      $returned_resolver
+    );
+  }
+
+  /**
+   * @covers ::getFieldResolverWithInheritance
+   */
+  public function testGetFieldResolverWithInheritanceTraversesMultipleInheritance() : void {
+    $expected_resolver = $this->builder->fromValue('Vehicle');
+    $this->mockResolver('Vehicle', 'model', $expected_resolver);
+
+    $returned_resolver = $this->registry->getFieldResolverWithInheritance(
+      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      'model'
+    );
+
+    self::assertEquals(
+      $expected_resolver,
+      $returned_resolver
+    );
+  }
+
+  /**
+   * @covers ::getFieldResolverWithInheritance
+   */
+  public function testGetFieldResolverWithInheritanceGivesPrecedenceToType() : void {
+    $this->mockResolver('Vehicle', 'model', $this->builder->fromValue('Vehicle'));
+    $expected_resolver = $this->builder->fromValue('Tesla');
+    $this->mockResolver('Tesla', 'model', $expected_resolver);
+
+    $returned_resolver = $this->registry->getFieldResolverWithInheritance(
+      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      'model'
+    );
+
+    self::assertEquals(
+      $expected_resolver,
+      $returned_resolver
+    );
+  }
+
+}

--- a/tests/src/Kernel/ResolverRegistryTest.php
+++ b/tests/src/Kernel/ResolverRegistryTest.php
@@ -32,7 +32,7 @@ class ResolverRegistryTest extends GraphQLTestBase {
         model: String
       }
 
-      type Tesla implements Car {
+      type Cabrio implements Car {
         model: String
       }
 GQL;
@@ -53,14 +53,14 @@ GQL;
     $this->mockResolver('Query', 'transportation', $transportation_resolver);
     $car_resolver = $this->builder->fromParent();
     $this->mockResolver('Car', 'model', $car_resolver);
-    $tesla_resolver = $this->builder->fromValue('Tesla');
-    $this->mockResolver('Tesla', 'model', $tesla_resolver);
+    $cabrio_resolver = $this->builder->fromValue('Cabrio');
+    $this->mockResolver('Cabrio', 'model', $cabrio_resolver);
 
     self::assertEquals(
       [
         'Query' => ['transportation' => $transportation_resolver],
         'Car' => ['model' => $car_resolver],
-        'Tesla' => ['model' => $tesla_resolver],
+        'Cabrio' => ['model' => $cabrio_resolver],
       ],
       $this->registry->getAllFieldResolvers()
     );
@@ -75,7 +75,7 @@ GQL;
     $this->mockResolver('Car', 'model', $expected_resolver);
 
     $returned_resolver = $this->registry->getFieldResolverWithInheritance(
-      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      $this->schema->getSchema($this->registry)->getType('Cabrio'),
       'model'
     );
 
@@ -93,7 +93,7 @@ GQL;
     $this->mockResolver('Vehicle', 'model', $expected_resolver);
 
     $returned_resolver = $this->registry->getFieldResolverWithInheritance(
-      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      $this->schema->getSchema($this->registry)->getType('Cabrio'),
       'model'
     );
 
@@ -108,11 +108,11 @@ GQL;
    */
   public function testGetFieldResolverWithInheritanceGivesPrecedenceToType() : void {
     $this->mockResolver('Vehicle', 'model', $this->builder->fromValue('Vehicle'));
-    $expected_resolver = $this->builder->fromValue('Tesla');
-    $this->mockResolver('Tesla', 'model', $expected_resolver);
+    $expected_resolver = $this->builder->fromValue('Cabrio');
+    $this->mockResolver('Cabrio', 'model', $expected_resolver);
 
     $returned_resolver = $this->registry->getFieldResolverWithInheritance(
-      $this->schema->getSchema($this->registry)->getType('Tesla'),
+      $this->schema->getSchema($this->registry)->getType('Cabrio'),
       'model'
     );
 

--- a/tests/src/Kernel/ValidatorTest.php
+++ b/tests/src/Kernel/ValidatorTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\graphql\Kernel;
 
 use Drupal\graphql\GraphQL\Validator;
-use Drupal\graphql\GraphQL\ValidatorInterface;
 
 /**
  * Tests that the GraphQL validator behaves correctly.
@@ -19,7 +18,7 @@ class ValidatorTest extends GraphQLTestBase {
    *
    * @var \Drupal\graphql\GraphQL\ValidatorInterface
    */
-  protected ValidatorInterface $validator;
+  protected $validator;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/ValidatorTest.php
+++ b/tests/src/Kernel/ValidatorTest.php
@@ -14,22 +14,6 @@ use Drupal\graphql\GraphQL\Validator;
 class ValidatorTest extends GraphQLTestBase {
 
   /**
-   * The validator under test.
-   *
-   * @var \Drupal\graphql\GraphQL\ValidatorInterface
-   */
-  protected $validator;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setUp(): void {
-    parent::setUp();
-
-    $this->validator = new Validator($this->schemaPluginManager);
-  }
-
-  /**
    * @covers ::getMissingResolvers
    */
   public function testGetMissingResolversCatchesMissingFieldsOnTypes() : void {
@@ -40,7 +24,8 @@ class ValidatorTest extends GraphQLTestBase {
 GQL;
     $this->setUpSchema($schema);
 
-    $missing_resolvers = $this->validator->getMissingResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $missing_resolvers = $validator->getMissingResolvers($this->server);
 
     self::assertEquals(
       ['Query' => ['me']],
@@ -72,7 +57,8 @@ GQL;
     $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
     $this->mockResolver('User', 'name', $this->builder->fromParent());
 
-    $missing_resolvers = $this->validator->getMissingResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $missing_resolvers = $validator->getMissingResolvers($this->server);
     self::assertEquals([], $missing_resolvers);
   }
 
@@ -92,7 +78,8 @@ GQL;
     $this->setUpSchema($schema);
     $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
 
-    $missing_resolvers = $this->validator->getMissingResolvers($this->server, ['User']);
+    $validator = new Validator($this->schemaPluginManager);
+    $missing_resolvers = $validator->getMissingResolvers($this->server, ['User']);
 
     self::assertEquals([], $missing_resolvers);
   }
@@ -115,7 +102,8 @@ GQL;
     $this->setUpSchema($schema);
     $this->mockResolver('Actor', 'name', $this->builder->fromValue('Never used'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server);
     self::assertEquals(['Actor' => ['name']], $orphaned_resolvers);
   }
 
@@ -133,7 +121,8 @@ GQL;
     $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
     $this->mockResolver('User', 'name', $this->builder->fromValue('Orphaned Name'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server);
     self::assertEquals(['User' => ['name']], $orphaned_resolvers);
   }
 
@@ -155,7 +144,8 @@ GQL;
     $this->mockResolver('User', 'name', $this->builder->fromParent());
     $this->mockResolver('User', 'birthday', $this->builder->fromValue('01-02-2021'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server);
     self::assertEquals(['User' => ['birthday']], $orphaned_resolvers);
   }
 
@@ -181,7 +171,8 @@ GQL;
     $this->mockResolver('Actor', 'name', $this->builder->fromParent());
     $this->mockResolver('Actor', 'birthday', $this->builder->fromValue('01-02-2021'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server);
     self::assertEquals(['Actor' => ['birthday']], $orphaned_resolvers);
   }
 
@@ -206,7 +197,8 @@ GQL;
     $this->setUpSchema($schema);
     $this->mockResolver('FakeInput', 'removed_field', $this->builder->fromValue('Test User'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server);
     self::assertEquals(['FakeInput' => ['removed_field']], $orphaned_resolvers);
   }
 
@@ -228,7 +220,8 @@ GQL;
     $this->setUpSchema($schema);
     $this->mockResolver('Actor', 'name', $this->builder->fromValue('Never used'));
 
-    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server, ['Actor']);
+    $validator = new Validator($this->schemaPluginManager);
+    $orphaned_resolvers = $validator->getOrphanedResolvers($this->server, ['Actor']);
     self::assertEquals([], $orphaned_resolvers);
   }
 

--- a/tests/src/Kernel/ValidatorTest.php
+++ b/tests/src/Kernel/ValidatorTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel;
+
+use Drupal\graphql\GraphQL\Validator;
+use Drupal\graphql\GraphQL\ValidatorInterface;
+
+/**
+ * Tests that the GraphQL validator behaves correctly.
+ *
+ * @coversDefaultClass \Drupal\graphql\GraphQL\Validator
+ *
+ * @group graphql
+ */
+class ValidatorTest extends GraphQLTestBase {
+
+  /**
+   * The validator under test.
+   *
+   * @var \Drupal\graphql\GraphQL\ValidatorInterface
+   */
+  protected ValidatorInterface $validator;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->validator = new Validator($this->schemaPluginManager);
+  }
+
+  /**
+   * @covers ::getMissingResolvers
+   */
+  public function testGetMissingResolversCatchesMissingFieldsOnTypes() : void {
+    $schema = <<<GQL
+      type Query {
+        me: String
+      }
+GQL;
+    $this->setUpSchema($schema);
+
+    $missing_resolvers = $this->validator->getMissingResolvers($this->server);
+
+    self::assertEquals(
+      ['Query' => ['me']],
+      $missing_resolvers
+    );
+  }
+
+  /**
+   * @covers ::getMissingResolvers
+   *
+   * Interfaces are ignored because the implementing types are used to check
+   * whether a resolver is present.
+   */
+  public function testGetMissingResolversIgnoresMissingFieldsOnInterfaces() : void {
+    $schema = <<<GQL
+      type Query {
+        me: Actor
+      }
+
+      interface Actor {
+        name: String!
+      }
+
+      type User implements Actor {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
+    $this->mockResolver('User', 'name', $this->builder->fromParent());
+
+    $missing_resolvers = $this->validator->getMissingResolvers($this->server);
+    self::assertEquals([], $missing_resolvers);
+  }
+
+  /**
+   * @covers ::getMissingResolvers
+   */
+  public function testGetMissingResolversCanIgnoreTypes() : void {
+    $schema = <<<GQL
+      type Query {
+        me: User
+      }
+
+      type User {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
+
+    $missing_resolvers = $this->validator->getMissingResolvers($this->server, ['User']);
+
+    self::assertEquals([], $missing_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsUnfieldableObjectResolvers() : void {
+    $schema = <<<GQL
+      type Query {
+        me: Actor
+      }
+
+      union Actor = User
+
+      type User {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Actor', 'name', $this->builder->fromValue('Never used'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    self::assertEquals(['Actor' => ['name']], $orphaned_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsNonExistentResolvers() : void {
+    $schema = <<<GQL
+      type Query {
+        me: String!
+      }
+
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
+    $this->mockResolver('User', 'name', $this->builder->fromValue('Orphaned Name'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    self::assertEquals(['User' => ['name']], $orphaned_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsOrphanedObjectFieldResolvers() : void {
+    $schema = <<<GQL
+      type Query {
+        me: User
+      }
+
+      type User {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
+    $this->mockResolver('User', 'name', $this->builder->fromParent());
+    $this->mockResolver('User', 'birthday', $this->builder->fromValue('01-02-2021'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    self::assertEquals(['User' => ['birthday']], $orphaned_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsOrphanedInterfaceFieldResolvers() : void {
+    $schema = <<<GQL
+      type Query {
+        me: Actor
+      }
+
+      interface Actor {
+        name: String!
+      }
+
+      type User implements Actor {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Query', 'me', $this->builder->fromValue('Test User'));
+    $this->mockResolver('Actor', 'name', $this->builder->fromParent());
+    $this->mockResolver('Actor', 'birthday', $this->builder->fromValue('01-02-2021'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    self::assertEquals(['Actor' => ['birthday']], $orphaned_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsOrphanedInputObjectFieldResolvers() : void {
+    $schema = <<<GQL
+      type Mutation {
+        createFakeObject(input: FakeInput!): User
+      }
+
+      type User {
+        name: String!
+      }
+
+      input FakeInput {
+        message: String!
+      }
+
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('FakeInput', 'removed_field', $this->builder->fromValue('Test User'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server);
+    self::assertEquals(['FakeInput' => ['removed_field']], $orphaned_resolvers);
+  }
+
+  /**
+   * @covers ::getOrphanedResolvers
+   */
+  public function testGetOrphanedResolversDetectsCanIgnoreTypes() : void {
+    $schema = <<<GQL
+      type Query {
+        me: Actor
+      }
+
+      union Actor = User
+
+      type User {
+        name: String!
+      }
+GQL;
+    $this->setUpSchema($schema);
+    $this->mockResolver('Actor', 'name', $this->builder->fromValue('Never used'));
+
+    $orphaned_resolvers = $this->validator->getOrphanedResolvers($this->server, ['Actor']);
+    self::assertEquals([], $orphaned_resolvers);
+  }
+
+}


### PR DESCRIPTION
This commit pulls the changes from https://github.com/goalgorilla/open_social/pull/2194 into the GraphQL module itself.

> Schema's can grow quickly and so can resolver definitions. To make sure mistakes are avoided, having an overview of orphaned and missing resolvers makes sure we can easily figure out whether we need to adjust the schema or can clean up resolver definitions. 

To achieve this functionality we implement `getAllFieldResolvers` and `getFieldResolverWithInheritance` on the `ResolverRegistry` class and interface. This is an interface addition that is backwards compatible for consumers but may require code changes for anyone implementing the interface without extending the `ResolverRegistry` class. These changes can be made before upgrading in a backwards compatible manner so this should be doable for libraries.

If we don't want to change the interface then we could put it on a separate interface that we implement with the `ResolverRegistry` class as well, immediately deprecating that interface with a notice that in the next major version it'll be moved into the main `ResolverRegistryInterface`. That separate interface could then be used as a requirement by the validator.

Using `getFieldResolverWithInheritance` this module now supports resolvers that are defined on interfaces that will be used by all implementing types. This relies on an interface that was added in webonyx/graphql-php `14.5.0` so this is now the minimum required version (this is a minor, SemVer compatible, update).

Closes: #978 

**Notable omissions**
- If a field returns properly typed data it may not need any further resolver definitions (an example is `PageInfo` within Open Social). However there is no way to detect this as the resolvers are opaque unless executed. This creates some false-negative reports.
- The validator supports ignoring certain types (this was used to solve the above issue as well as ignore the `Subscription` type since we implement this outside of Drupal) but this is not yet implemented in the Controller. This would require some kind of management UI and storage in configuration (since hard-coding does not work outside of Open Social ;-) ). This should be picked up in a follow-up. I don't currently have time to implement that.