### PR TITLE
Fix swapped errors and extensions in executor

### DIFF
--- a/config/install/graphql.settings.yml
+++ b/config/install/graphql.settings.yml
@@ -1,0 +1,1 @@
+deprecated_swap_errors_and_extensions_in_results: false

--- a/config/schema/graphql.schema.yml
+++ b/config/schema/graphql.schema.yml
@@ -1,3 +1,12 @@
+graphql.settings:
+  type: config_object
+  label: "GraphQL Settings"
+  mapping:
+    deprecated_swap_errors_and_extensions_in_results:
+      type: boolean
+      label: "Return `errors` in the GraphQL response `extension` key and vice versa"
+      description: "Preserves behaviour that was caused by a bug that caused errors to appear in the extensions key of GraphQL results. Ensures misbehaving client implementations don't break by fixing this bug. Will be removed in 5.0.0"
+
 graphql.graphql_servers.*:
   type: config_entity
   label: 'Server'

--- a/graphql.install
+++ b/graphql.install
@@ -63,3 +63,12 @@ function graphql_update_8001(): void {
     $server->save();
   }
 }
+
+/**
+ * Preserve incorrect error reporting behaviour for PR #1161.
+ */
+function graphql_update_8400() :void {
+  \Drupal::configFactory()->getEditable('graphql.settings')
+    ->set('deprecated_swap_errors_and_extensions_in_results', TRUE)
+    ->save();
+}

--- a/src/GraphQL/Execution/Executor.php
+++ b/src/GraphQL/Execution/Executor.php
@@ -223,7 +223,13 @@ class Executor implements ExecutorImplementation {
     return $this->doExecuteUncached()->then(function ($result) {
       $this->context->mergeCacheMaxAge(0);
 
-      $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
+      // @todo keep only else case in 5.0.0.
+      if (\Drupal::config('graphql.settings')->get('deprecated_swap_errors_and_extensions_in_results')) {
+        $result = new CacheableExecutionResult($result->data, $result->extensions, $result->errors);
+      }
+      else {
+        $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
+      }
       $result->addCacheableDependency($this->context);
       return $result;
     });
@@ -246,7 +252,13 @@ class Executor implements ExecutorImplementation {
         $this->context->mergeCacheMaxAge(0);
       }
 
-      $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
+      // @todo keep only else case in 5.0.0.
+      if (\Drupal::config('graphql.settings')->get('deprecated_swap_errors_and_extensions_in_results')) {
+        $result = new CacheableExecutionResult($result->data, $result->extensions, $result->errors);
+      }
+      else {
+        $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
+      }
       $result->addCacheableDependency($this->context);
       if ($result->getCacheMaxAge() !== 0) {
         $this->cacheWrite($prefix, $result);

--- a/src/GraphQL/Execution/Executor.php
+++ b/src/GraphQL/Execution/Executor.php
@@ -223,7 +223,7 @@ class Executor implements ExecutorImplementation {
     return $this->doExecuteUncached()->then(function ($result) {
       $this->context->mergeCacheMaxAge(0);
 
-      $result = new CacheableExecutionResult($result->data, $result->extensions, $result->errors);
+      $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
       $result->addCacheableDependency($this->context);
       return $result;
     });
@@ -246,7 +246,7 @@ class Executor implements ExecutorImplementation {
         $this->context->mergeCacheMaxAge(0);
       }
 
-      $result = new CacheableExecutionResult($result->data, $result->extensions, $result->errors);
+      $result = new CacheableExecutionResult($result->data, $result->errors, $result->extensions);
       $result->addCacheableDependency($this->context);
       if ($result->getCacheMaxAge() !== 0) {
         $this->cacheWrite($prefix, $result);


### PR DESCRIPTION
The module wraps the library's ExecutionResult to implement caching. While doing so it swaps around the GraphQL errors and extension fields. This causes all errors to be returned in the `extensions` field of the GraphQL response. This means that client libraries generally aren't aware of errors and breaks a lot of test expectations.

The below image shows the currently implemented order as well as the expected order in the form of parameter hints.
![image](https://user-images.githubusercontent.com/327697/107377440-43a9ea80-6aeb-11eb-971d-8fa0052bda9f.png)

This solves a discussion on Slack from last year (that I apparently didn't convert into a bug report): https://drupal.slack.com/archives/C6LMJ0ZAT/p1607614511153500

This probably fixes #1030

Resolving this issue ensures that GraphQL clients can actually handle the errors that are reported by Drupal.