### PR TITLE
Add origin of error in QueryResultAssertionTrait output

### DIFF
--- a/tests/src/Traits/QueryResultAssertionTrait.php
+++ b/tests/src/Traits/QueryResultAssertionTrait.php
@@ -165,7 +165,13 @@ trait QueryResultAssertionTrait {
       }
 
       if (!$match) {
-        $unexpected[] = $error_message;
+        // Add error location information of the original error in the chain to
+        // show developers where to look.
+        $original_error = $error;
+        while ($original_error->getPrevious() !== NULL) {
+          $original_error = $original_error->getPrevious();
+        }
+        $unexpected[] = "Error message: ${error_message}\n  Originated in: {$original_error->getFile()}:{$original_error->getLine()}";
       }
     }
 


### PR DESCRIPTION
This is dependant on the work done in #1159 which should be merged first. That PR makes the error information available that's added here.

It's great that the `QueryResultAssertionTrait` outputs the error message to the developer. However, in case of some errors the error itself doesn't provide a lot of useful information.

This pull request provides the filename and line number of the original error to give developers a starting point from test output. This is especially helpful in Test Driven Development environments when a simple typo may show up in a test.

Below is the output when the test runner is used in an IDE like PHPStorm. The output after the PR allows a developer to quickly jump to the line that caused the error.

**Original test output**
![Screenshot 2021-02-09 at 16 02 45](https://user-images.githubusercontent.com/327697/107383307-2a0ba180-6af1-11eb-9d18-a97e45559b69.png)

**Test output after PR**
![Screenshot 2021-02-09 at 16 02 11](https://user-images.githubusercontent.com/327697/107383317-2bd56500-6af1-11eb-98b1-1e831fd7b483.png)
