### PR TITLE
Fix configuration schema sequence for enabled extensions

### DIFF
--- a/config/schema/graphql.schema.yml
+++ b/config/schema/graphql.schema.yml
@@ -28,7 +28,7 @@ graphql.graphql_servers.*:
       label: 'Schema configuration'
       orderby: key
       sequence:
-        type: 'graphql.schema.[%key]'
+        type: 'graphql.schema.[%parent.schema]'
         label: 'The configuration for a single schema extension.'
     persisted_queries_settings:
       type: sequence

--- a/config/schema/graphql.schema.yml
+++ b/config/schema/graphql.schema.yml
@@ -24,7 +24,12 @@ graphql.graphql_servers.*:
       type: boolean
       label: 'Batching'
     schema_configuration:
-      type: 'graphql.schema.[%parent.schema]'
+      type: sequence
+      label: 'Schema configuration'
+      orderby: key
+      sequence:
+        type: 'graphql.schema.[%key]'
+        label: 'The configuration for a single schema extension.'
     persisted_queries_settings:
       type: sequence
       label: 'Persisted queries settings'
@@ -34,7 +39,7 @@ graphql.graphql_servers.*:
         label: 'The configuration for a single persisted query plugin.'
 
 graphql.schema.*:
-  type: mapping
+  type: graphql.schema.composable
   label: 'Schema settings'
 
 graphql.schema.composable:
@@ -45,7 +50,7 @@ graphql.schema.composable:
       label: Enabled extensions
       type: sequence
       sequence:
-        type: boolean
+        type: string
 
 graphql.default_persisted_query_configuration:
   type: mapping


### PR DESCRIPTION
The configuration schema for enabled sequences seems to be missing a sequence. Also the type of an enabled extension was wrong.
You can recreate this by enabling some extensions and use config_inspector which will show you an error in `schema_configuration`, the part for sequences.