### PR TITLE
fix(multiple): Fix checking of multi value field

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/Multiple.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/Multiple.php
@@ -38,7 +38,7 @@ class Multiple extends DataProducerPluginBase {
     if ($entity_definition_field instanceof FieldStorageDefinitionInterface) {
       return $entity_definition_field->isMultiple();
     }
-    return $entity_definition_field->isList();
+    return $entity_definition_field->getFieldStorageDefinition()->isMultiple();
   }
 
 }

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -318,8 +318,8 @@ class EntityDefinitionTest extends GraphQLTestBase {
           'description' => '',
           'type' => 'text',
           'required' => FALSE,
-          'multiple' => FALSE,
-          'maxNumItems' => 1,
+          'multiple' => TRUE,
+          'maxNumItems' => -1,
           'status' => TRUE,
           'defaultValue' => NULL,
           'isReference' => FALSE,
@@ -346,6 +346,7 @@ class EntityDefinitionTest extends GraphQLTestBase {
       'field_name' => 'field_test',
       'type' => 'text',
       'entity_type' => 'node',
+      'cardinality' => -1,
     ]);
     $field_storage->save();
 

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\graphql\Kernel\DataProducer;
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
@@ -346,7 +347,7 @@ class EntityDefinitionTest extends GraphQLTestBase {
       'field_name' => 'field_test',
       'type' => 'text',
       'entity_type' => 'node',
-      'cardinality' => -1,
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
     ]);
     $field_storage->save();
 

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -318,7 +318,7 @@ class EntityDefinitionTest extends GraphQLTestBase {
           'description' => '',
           'type' => 'text',
           'required' => FALSE,
-          'multiple' => TRUE,
+          'multiple' => FALSE,
           'maxNumItems' => 1,
           'status' => TRUE,
           'defaultValue' => NULL,


### PR DESCRIPTION
The multiple resolver currently returns true for resolvers that are set to "Allowed number of values: Limited; 1"
This PR provides a fix by reading the correct settings.
 
I added a cardinality (-1) and changed the maxNumItems to -1.