### PR TITLE
Update $modules property to protected in test classes

### DIFF
--- a/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageDerivativeTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/Fields/Image/ImageDerivativeTest.php
@@ -18,7 +18,7 @@ class ImageDerivativeTest extends GraphQLTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['image', 'file'];
+  protected static $modules = ['image', 'file'];
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -20,7 +20,7 @@ class EntityDefinitionTest extends GraphQLTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'text',
   ];
 

--- a/tests/src/Kernel/Framework/PersistedQueriesTest.php
+++ b/tests/src/Kernel/Framework/PersistedQueriesTest.php
@@ -12,7 +12,7 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 class PersistedQueriesTest extends GraphQLTestBase {
 
   /**
-   * @var string[]
+   * {@inheritdoc}
    */
   protected static $modules = [
     'graphql_persisted_queries_test',

--- a/tests/src/Kernel/Framework/PersistedQueriesTest.php
+++ b/tests/src/Kernel/Framework/PersistedQueriesTest.php
@@ -14,7 +14,7 @@ class PersistedQueriesTest extends GraphQLTestBase {
   /**
    * @var string[]
    */
-  public static $modules = [
+  protected static $modules = [
     'graphql_persisted_queries_test',
   ];
 

--- a/tests/src/Kernel/Framework/UploadFileServiceTest.php
+++ b/tests/src/Kernel/Framework/UploadFileServiceTest.php
@@ -18,7 +18,7 @@ class UploadFileServiceTest extends GraphQLTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['file'];
+  protected static $modules = ['file'];
 
   /**
    * The FileUpload object we want to test, gets prepared in setUp().

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -29,7 +29,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'language',

--- a/tests/src/Kernel/ResolverBuilderTest.php
+++ b/tests/src/Kernel/ResolverBuilderTest.php
@@ -17,7 +17,7 @@ class ResolverBuilderTest extends GraphQLTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['graphql_resolver_builder_test'];
+  protected static $modules = ['graphql_resolver_builder_test'];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Fixes #1172 

Changes proposed in this pull request:

* Update $modules property to protected in test classes
  * Due to https://www.drupal.org/node/2909426 
* Update DocBlock for consistency in `PersistedQueriesTest.php`
  * `{@inheritdoc}` is used in all other places, let's do the same here