### PR TITLE
Add optional language parameter to route_load data producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
@@ -24,6 +24,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   consumes = {
  *     "path" = @ContextDefinition("string",
  *       label = @Translation("Path")
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Language"),
+ *       required = FALSE
  *     )
  *   }
  * )
@@ -87,17 +91,24 @@ class RouteLoad extends DataProducerPluginBase implements ContainerFactoryPlugin
   }
 
   /**
-   * Resolver.
+   * The resolver.
    *
    * @param string $path
+   *   The source path.
+   *
+   * @param string $language
+   *   The language code.
+   *
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
+   *   Cache metadata.
    *
    * @return \Drupal\Core\Url|null
+   *   The Drupal URL object or NULL if not found.
    */
-  public function resolve($path, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve($path, $language, RefinableCacheableDependencyInterface $metadata) {
     if ($this->redirectRepository) {
       /** @var \Drupal\redirect\Entity\Redirect|null $redirect */
-      $redirect = $this->redirectRepository->findMatchingRedirect($path, []);
+      $redirect = $this->redirectRepository->findMatchingRedirect($path, [], $language);
       if ($redirect) {
         return $redirect->getRedirectUrl();
       }

--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
@@ -91,19 +91,13 @@ class RouteLoad extends DataProducerPluginBase implements ContainerFactoryPlugin
   }
 
   /**
-   * The resolver.
+   * Resolver.
    *
    * @param string $path
-   *   The source path.
-   *
    * @param string $language
-   *   The language code.
-   *
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
-   *   Cache metadata.
    *
    * @return \Drupal\Core\Url|null
-   *   The Drupal URL object or NULL if not found.
    */
   public function resolve($path, $language, RefinableCacheableDependencyInterface $metadata) {
     if ($this->redirectRepository) {


### PR DESCRIPTION
Added an optional language parameter to the route_load producer.

Without it, the redirect won't be retrieved for specific languages because the fallback is to LANGCODE_NOT_SPECIFIED, and in most cases redirects are set for a specific language. For example, if a node in a specific language is renamed, and gets a new alias, a redirect is created in for the language of that specific node.