### PR TITLE
Add optional language parameter to route_load data

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
@@ -22,6 +22,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   consumes = {
  *     "path" = @ContextDefinition("string",
  *       label = @Translation("Path")
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Language"),
+ *       required = FALSE
  *     )
  *   }
  * )
@@ -89,14 +93,15 @@ class RouteLoad extends DataProducerPluginBase implements ContainerFactoryPlugin
 
   /**
    * @param string $path
+   * @param string $language
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $metadata
    *
    * @return \Drupal\Core\Url|null
    */
-  public function resolve($path, RefinableCacheableDependencyInterface $metadata) {
+  public function resolve($path, $language, RefinableCacheableDependencyInterface $metadata) {
     if ($this->redirectRepository) {
       /** @var \Drupal\redirect\Entity\Redirect|null $redirect */
-      $redirect = $this->redirectRepository->findMatchingRedirect($path, []);
+      $redirect = $this->redirectRepository->findMatchingRedirect($path, [], $language);
       if ($redirect) {
         return $redirect->getRedirectUrl();
       }


### PR DESCRIPTION
Added an optional language parameter to the route_load producer.

Without it, the redirect won't be retrieved for specific languages because the fallback is to LANGCODE_NOT_SPECIFIED, and in most cases redirects are set for a specific language. For example, if a node in a specific language is renamed, and gets a new alias, a redirect is created in for the language of that specific node.