### PR TITLE
Add Data Producer plugins for creating, updating and deleting entities.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/CreateEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/CreateEntity.php
@@ -65,8 +65,18 @@ class CreateEntity extends DataProducerPluginBase implements ContainerFactoryPlu
     $storage = $this->entityTypeManager->getStorage($entity_type);
     $accessHandler = $this->entityTypeManager->getAccessControlHandler($entity_type);
 
+    // Infer the bundle type from the response and return an error if the entity
+    // type expects one, but one is not present.
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type);
+    $bundle = $entity_type->getKey('bundle') && !empty($values[$entity_type->getKey('bundle')]) ? $values[$entity_type->getKey('bundle')] : NULL;
+    if ($entity_type->getKey('bundle') && !$bundle) {
+      return [
+        'errors' => [$this->t('Entity type being created requried a bundle, but none was present.')],
+      ];
+    }
+
     // Ensure the user has access to create this kind of entity.
-    $access = $accessHandler->createAccess(NULL, NULL, [], TRUE);
+    $access = $accessHandler->createAccess($bundle, NULL, [], TRUE);
     $context->addCacheableDependency($access);
     if (!$access->isAllowed()) {
       return [

--- a/src/Plugin/GraphQL/DataProducer/Entity/CreateEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/CreateEntity.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
+
+use Drupal\Core\Access\AccessResultReasonInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\EntityValidationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Creates an entity.
+ *
+ * @DataProducer(
+ *   id = "create_entity",
+ *   name = @Translation("Create Entity"),
+ *   produces = @ContextDefinition("entity",
+ *     label = @Translation("Entity")
+ *   ),
+ *   consumes = {
+ *     "entity_type" = @ContextDefinition("string",
+ *       label = @Translation("Entity Type"),
+ *       required = TRUE
+ *     ),
+ *     "values" = @ContextDefinition("any",
+ *       label = @Translation("Values to update"),
+ *       required = TRUE
+ *     ),
+ *     "entity_return_key" = @ContextDefinition("string",
+ *       label = @Translation("Entity Return Key"),
+ *       required = TRUE
+ *     ),
+ *     "save" = @ContextDefinition("boolean",
+ *       label = @Translation("Save entity"),
+ *       required = FALSE,
+ *       default_value = TRUE,
+ *     ),
+ *   }
+ * )
+ */
+class CreateEntity extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  use EntityValidationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
+  }
+
+  /**
+   * Resolve the values for this producer.
+   */
+  public function resolve(string $entity_type, array $values, string $entity_return_key, ?bool $save, $context) {
+    $storage = $this->entityTypeManager->getStorage($entity_type);
+    $accessHandler = $this->entityTypeManager->getAccessControlHandler($entity_type);
+
+    // Ensure the user has access to create this kind of entity.
+    $access = $accessHandler->createAccess(NULL, NULL, [], TRUE);
+    $context->addCacheableDependency($access);
+    if (!$access->isAllowed()) {
+      return [
+        'errors' => [$access instanceof AccessResultReasonInterface && $access->getReason() ? $access->getReason() : 'Access was forbidden.'],
+      ];
+    }
+
+    $entity = $storage->create($values);
+    if ($violation_messages = $this->getViolationMessages($entity)) {
+      return [
+        'errors' => $violation_messages,
+      ];
+    }
+
+    if ($save) {
+      $entity->save();
+    }
+    return [
+      $entity_return_key => $entity,
+    ];
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/Entity/DeleteEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/DeleteEntity.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
+
+use Drupal\Core\Access\AccessResultReasonInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+
+/**
+ * Deletes an entity.
+ *
+ * @DataProducer(
+ *   id = "delete_entity",
+ *   name = @Translation("Delete Entity"),
+ *   produces = @ContextDefinition("entities",
+ *     label = @Translation("Entities")
+ *   ),
+ *   consumes = {
+ *     "entity" = @ContextDefinition("entity",
+ *       label = @Translation("Entity")
+ *     ),
+ *   }
+ * )
+ */
+class DeleteEntity extends DataProducerPluginBase {
+
+  /**
+   * Resolve the values for this producer.
+   */
+  public function resolve(ContentEntityInterface $entity, $context) {
+    $access = $entity->access('delete', NULL, TRUE);
+    $context->addCacheableDependency($access);
+    if (!$access->isAllowed()) {
+      return [
+        'was_successful' => FALSE,
+        'errors' => [$access instanceof AccessResultReasonInterface ? $access->getReason() : 'Access was forbidden.'],
+      ];
+    }
+
+    $entity->delete();
+    return [
+      'was_successful' => TRUE,
+    ];
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/Entity/UpdateEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/UpdateEntity.php
@@ -51,6 +51,9 @@ class UpdateEntity extends DataProducerPluginBase {
     // Filter out keys the user does not have access to update, this may include
     // things such as the owner of the entity or the ID of the entity.
     $update_fields = array_filter($values, function (string $field_name) use ($entity, $context) {
+      if (!$entity->hasField($field_name)) {
+        throw new \Exception("Could not update '$field_name' field, since it does not exist on the given entity.");
+      }
       $access = $entity->{$field_name}->access('edit', NULL, TRUE);
       $context->addCacheableDependency($access);
       return $access->isAllowed();

--- a/src/Plugin/GraphQL/DataProducer/Entity/UpdateEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/UpdateEntity.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Entity;
+
+use Drupal\Core\Access\AccessResultReasonInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\EntityValidationTrait;
+
+/**
+ * Updates entity values.
+ *
+ * @DataProducer(
+ *   id = "update_entity",
+ *   name = @Translation("Update Entity"),
+ *   produces = @ContextDefinition("entities",
+ *     label = @Translation("Entities")
+ *   ),
+ *   consumes = {
+ *     "entity" = @ContextDefinition("entity",
+ *       label = @Translation("Entity")
+ *     ),
+ *     "values" = @ContextDefinition("any",
+ *       label = @Translation("Values to update"),
+ *       required = TRUE
+ *     ),
+ *     "entity_return_key" = @ContextDefinition("string",
+ *       label = @Translation("Entity Return Key"),
+ *       required = TRUE
+ *     ),
+ *   }
+ * )
+ */
+class UpdateEntity extends DataProducerPluginBase {
+
+  use EntityValidationTrait;
+
+  /**
+   * Resolve the values for this producer.
+   */
+  public function resolve(ContentEntityInterface $entity, array $values, string $entity_return_key, $context) {
+    // Ensure the user has access to perform an update.
+    $access = $entity->access('update', NULL, TRUE);
+    $context->addCacheableDependency($access);
+    if (!$access->isAllowed()) {
+      return [
+        'errors' => [$access instanceof AccessResultReasonInterface ? $access->getReason() : 'Access was forbidden.'],
+      ];
+    }
+
+    // Filter out keys the user does not have access to update, this may include
+    // things such as the owner of the entity or the ID of the entity.
+    $update_fields = array_filter($values, function (string $field_name) use ($entity, $context) {
+      $access = $entity->{$field_name}->access('edit', NULL, TRUE);
+      $context->addCacheableDependency($access);
+      return $access->isAllowed();
+    }, ARRAY_FILTER_USE_KEY);
+
+    // Hydrate the entity with the values.
+    foreach ($update_fields as $field_name => $field_value) {
+      $entity->set($field_name, $field_value);
+    }
+
+    if ($violation_messages = $this->getViolationMessages($entity)) {
+      return [
+        'errors' => $violation_messages,
+      ];
+    }
+
+    // Once access has been granted, the save can be committed and the entity
+    // can be returned to the client.
+    $entity->save();
+    return [
+      $entity_return_key => $entity,
+    ];
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/EntityValidationTrait.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityValidationTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\graphql\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Trait for entity validation.
+ *
+ * Ensure the entity passes validation, any violations will be reported back
+ * to the client. Validation will catch issues like invalid referenced entities,
+ * incorrect text formats, required fields etc. Additional validation of input
+ * should not be put here, but instead should be built into the entity
+ * validation system, so the same constraints are applied in the Drupal admin.
+ */
+trait EntityValidationTrait {
+
+  /**
+   * Get violation messages from an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   An entity to validate.
+   *
+   * @return array|null
+   *   Get a list of violations or NULL if none were found.
+   */
+  public function getViolationMessages(ContentEntityInterface $entity) {
+    $violations = $entity->validate();
+    if ($violations->count() > 0) {
+      $violation_messages = [];
+      foreach ($violations as $violation) {
+        $violation_messages[] = sprintf('%s: %s', $violation->getPropertyPath(), strip_tags($violation->getMessage()));
+      }
+      return $violation_messages;
+    }
+    return NULL;
+  }
+
+}

--- a/src/Plugin/GraphQL/DataProducer/EntityValidationTrait.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityValidationTrait.php
@@ -21,11 +21,16 @@ trait EntityValidationTrait {
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   An entity to validate.
    *
-   * @return array|null
-   *   Get a list of violations or NULL if none were found.
+   * @return array
+   *   Get a list of violations.
    */
-  public function getViolationMessages(ContentEntityInterface $entity) {
+  public function getViolationMessages(ContentEntityInterface $entity): array {
     $violations = $entity->validate();
+
+    // Remove violations of inaccessible fields as they cannot stem from our
+    // changes.
+    $violations->filterByFieldAccess();
+
     if ($violations->count() > 0) {
       $violation_messages = [];
       foreach ($violations as $violation) {
@@ -33,7 +38,7 @@ trait EntityValidationTrait {
       }
       return $violation_messages;
     }
-    return NULL;
+    return [];
   }
 
 }

--- a/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel\DataProducer\Entity;
+
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql\Traits\DataProducerExecutionTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Test the CreateEntity producer.
+ *
+ * @group graphql
+ */
+class CreateEntityTest extends GraphQLTestBase {
+
+  use DataProducerExecutionTrait;
+  use UserCreationTrait;
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  protected $pluginId = 'create_entity';
+
+  /**
+   * Test creating entities.
+   */
+  public function testCreateEntity() {
+    $content_type = NodeType::create([
+      'type' => 'lorem',
+      'name' => 'ipsum',
+    ]);
+    $content_type->save();
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'values' => [],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame('Access was forbidden.', $result['errors'][0]);
+
+    $this->setCurrentUser($this->createUser(['bypass node access', 'access content']));
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'values' => [
+        'type' => 'lorem'
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame([
+      'title: This value should not be null.',
+    ], $result['errors']);
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'save' => TRUE,
+      'values' => [
+        'type' => 'lorem',
+        'title' => 'bar',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertEquals('bar', $result['foo']->label());
+    $this->assertFalse($result['foo']->isNew());
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'save' => FALSE,
+      'values' => [
+        'type' => 'lorem',
+        'title' => 'bar',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertEquals('bar', $result['foo']->label());
+    $this->assertTrue($result['foo']->isNew());
+  }
+
+}

--- a/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
@@ -43,7 +43,9 @@ class CreateEntityTest extends GraphQLTestBase {
   public function testCreateEntity() {
     $result = $this->executeDataProducer($this->pluginId, [
       'entity_type' => 'node',
-      'values' => [],
+      'values' => [
+        'type' => 'lorem',
+      ],
       'entity_return_key' => 'foo',
     ]);
     $this->assertSame('Access was forbidden.', (string) $result['errors'][0]);
@@ -101,6 +103,18 @@ class CreateEntityTest extends GraphQLTestBase {
       'entity_return_key' => 'foo',
     ]);
     $this->assertSame('nid: The entity ID cannot be changed.', (string) $result['errors'][0]);
+  }
+
+  /**
+   * Test creating an entity with a missing bundle.
+   */
+  public function testCreateEntityMissingBundle() {
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'values' => [],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame('Entity type being created requried a bundle, but none was present.', (string) $result['errors'][0]);
   }
 
 }

--- a/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/CreateEntityTest.php
@@ -25,21 +25,28 @@ class CreateEntityTest extends GraphQLTestBase {
   protected $pluginId = 'create_entity';
 
   /**
-   * Test creating entities.
+   * {@inheritdoc}
    */
-  public function testCreateEntity() {
+  protected function setUp(): void {
+    parent::setUp();
+
     $content_type = NodeType::create([
       'type' => 'lorem',
       'name' => 'ipsum',
     ]);
     $content_type->save();
+  }
 
+  /**
+   * Test creating entities.
+   */
+  public function testCreateEntity() {
     $result = $this->executeDataProducer($this->pluginId, [
       'entity_type' => 'node',
       'values' => [],
       'entity_return_key' => 'foo',
     ]);
-    $this->assertSame('Access was forbidden.', $result['errors'][0]);
+    $this->assertSame('Access was forbidden.', (string) $result['errors'][0]);
 
     $this->setCurrentUser($this->createUser(['bypass node access', 'access content']));
 
@@ -77,6 +84,23 @@ class CreateEntityTest extends GraphQLTestBase {
     ]);
     $this->assertEquals('bar', $result['foo']->label());
     $this->assertTrue($result['foo']->isNew());
+  }
+
+  /**
+   * Test field access when creating entities.
+   */
+  public function testCreateEntityFieldAccess() {
+    $this->setCurrentUser($this->createUser(['bypass node access', 'access content']));
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity_type' => 'node',
+      'values' => [
+        'type' => 'lorem',
+        'nid' => 123,
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame('nid: The entity ID cannot be changed.', (string) $result['errors'][0]);
   }
 
 }

--- a/tests/src/Kernel/DataProducer/Entity/DeleteEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/DeleteEntityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel\DataProducer\Entity;
+
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql\Traits\DataProducerExecutionTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Test the DeleteEntity producer.
+ *
+ * @group graphql
+ */
+class DeleteEntityTest extends GraphQLTestBase {
+
+  use DataProducerExecutionTrait;
+  use UserCreationTrait;
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  protected $pluginId = 'delete_entity';
+
+  /**
+   * Test deleting entities.
+   */
+  public function testDeleteEntity() {
+    $content_type = NodeType::create([
+      'type' => 'lorem',
+      'name' => 'ipsum',
+    ]);
+    $content_type->save();
+
+    $node = Node::create([
+      'type' => 'lorem',
+      'title' => 'foo',
+    ]);
+    $node->save();
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $node,
+    ]);
+    $this->assertSame("The 'delete any lorem content' permission is required.", $result['errors'][0]);
+
+    $account = $this->createUser(['bypass node access']);
+    $this->setCurrentUser($account);
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $node,
+    ]);
+    $this->assertTrue($result['was_successful']);
+    $this->assertNull(Node::load($node->id()));
+  }
+
+}

--- a/tests/src/Kernel/DataProducer/Entity/UpdateEntityTest.php
+++ b/tests/src/Kernel/DataProducer/Entity/UpdateEntityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel\DataProducer\Entity;
+
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql\Traits\DataProducerExecutionTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Test the UpdateEntity producer.
+ *
+ * @group graphql
+ */
+class UpdateEntityTest extends GraphQLTestBase {
+
+  use DataProducerExecutionTrait;
+  use UserCreationTrait;
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  protected $pluginId = 'update_entity';
+
+  /**
+   * Test updating an entity.
+   */
+  public function testUpdateEntity() {
+    $content_type = NodeType::create([
+      'type' => 'lorem',
+      'name' => 'ipsum',
+    ]);
+    $content_type->save();
+
+    $entity = Node::create([
+      'type' => 'lorem',
+      'title' => 'foo',
+      'uuid' => 'adf834bd-9e70-4c2a-bf8a-3ef2382e1d78',
+    ]);
+    $entity->save();
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $entity,
+      'values' => [
+        'title' => 'bar',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame("The 'edit any lorem content' permission is required.", $result['errors'][0]);
+
+    $this->setCurrentUser($this->createUser(['bypass node access', 'access content']));
+
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $entity,
+      'values' => [
+        'type' => 'something_wacky',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertSame('type.0.target_id: The referenced entity (node_type: something_wacky) does not exist.', $result['errors'][0]);
+
+    // Reload the article, since the data producer hydrates the passed in entity
+    // with values, but does not reset them.
+    $entity = Node::load($entity->id());
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $entity,
+      'values' => [
+        'title' => 'bar',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertEquals('bar', $result['foo']->label());
+
+    // Fields which do not pass field-access checks are filtered out.
+    $result = $this->executeDataProducer($this->pluginId, [
+      'entity' => $entity,
+      'values' => [
+        'uuid' => '1c41245d-d173-4861-8524-8dd50ef7668d',
+      ],
+      'entity_return_key' => 'foo',
+    ]);
+    $this->assertArrayNotHasKey('errors', $result);
+    $this->assertEquals('adf834bd-9e70-4c2a-bf8a-3ef2382e1d78', $result['foo']->uuid());
+  }
+
+}


### PR DESCRIPTION
I have a site with a number of entity types that are linked to mutations for a fairly standard set of CRUD operations. One thing I found that was missing from the module was a fairly generic set of create/update/delete data producers. I built some, which I have been using which are entity type agnostic, so submitting as a PR in case they are useful upstream.

I'm not sure if this fits in with the ethos of module, which seems focused on empowering folks to connect schema to plain PHP entry points, where they can interface with Drupal entities (or anything else) however they like - directly, but I think these could potentially cover a few blindspots that folks often miss, like entity validation or field access. With the number of entity types I was required to put together, I think writing code for each one individually, without an abstraction, to validate access, fields etc. would have been a bit impractical.

Here are some simplified examples of how I've integrated them into my project, but the builder object seems flexible enough that you could mix and match these producers in various ways.

Creating an entity called article:

```
    $registry->addFieldResolver('Mutation', 'create_article',
      $builder->produce('create_entity')
        ->map('values', $builder->fromArgument('data'))
        ->map('entity_type', $builder->fromValue('article'))
        ->map('entity_return_key', $builder->fromValue('article'))
    );
```

Updating it:
```
$registry->addFieldResolver('Mutation', 'update_article',
      $builder->produce('update_entity')
        ->map('values', $builder->fromArgument('data'))
        ->map('entity_return_key', $builder->fromValue('article'))
        ->map(
          'entity',
          $builder->produce('entity_load')
            ->map('access', $builder->fromValue(FALSE))
            ->map('type', $builder->fromValue($entity_type_id))
            ->map('id', $builder
              ->produce('access_array')
              ->map('input', $builder->fromArgument('data'))
              ->map('key', $builder->fromValue('id'))
            )
        )
    );
```

A specific mutation to publish an entity:
```
    $registry->addFieldResolver('Mutation', 'publish_article',
      $builder->produce('update_entity')
        ->map('values', $builder->fromValue([
          'published' => TRUE,
        ]))
        ->map('entity_return_key', $builder->fromValue('article'))
        ->map(
          'entity',
          $builder->produce('entity_load')
            ->map('access', $builder->fromValue(FALSE))
            ->map('type', $builder->fromValue('article'))
            ->map('id', $builder
              ->produce('access_array')
              ->map('input', $builder->fromArgument('data'))
              ->map('key', $builder->fromValue('id'))
            )
        )
    );
```

A delete:
```
$registry->addFieldResolver('Mutation', 'delete_article',
      $builder->produce('delete_entity')
        ->map(
          'entity',
          $builder->produce('entity_load')
            ->map('access', $builder->fromValue(FALSE))
            ->map('type', $builder->fromValue('article'))
            ->map('id', $builder
              ->produce('access_array')
              ->map('input', $builder->fromArgument('data'))
              ->map('key', $builder->fromValue('id'))
            )
        )
    );
```

The schema:

```
    input OperationInput {
        id: ID!
    }
    type OperationMutationResponse {
        was_successful: Boolean!
        errors: [Violation!]
    }
    input CreateArticleInput {
        use_case: ID!
        name: String!
        body: String!
        published: Boolean
    }
    input UpdateArticleInput {
        id: ID!
        name: String
        body: String
        published: Boolean
    }
    
    type ArticleMutationResponse {
        article: Article
        errors: [Violation!]
    }

    create_article(data: CreateArticleInput): ArticleMutationResponse
    update_article(data: UpdateArticleInput): ArticleMutationResponse
    publish_article(data: OperationInput): OperationMutationResponse
    delete_article(data: OperationInput): OperationMutationResponse
```
