### PR TITLE
feat: Add configurable validation rules

### DIFF
--- a/config/schema/graphql.schema.yml
+++ b/config/schema/graphql.schema.yml
@@ -23,6 +23,18 @@ graphql.graphql_servers.*:
     batching:
       type: boolean
       label: 'Batching'
+    disable_introspection:
+      type: boolean
+      label: 'Disable Introspection'
+    depth:
+      type: number
+      label: 'Max query depth'
+    complexity:
+      type: number
+      label: 'Max query complexity'
+    bypass_validation_token:
+      type: string
+      label: 'Bypass validation token'
     schema_configuration:
       type: 'graphql.schema.[%parent.schema]'
     persisted_queries_settings:

--- a/graphql.services.yml
+++ b/graphql.services.yml
@@ -108,6 +108,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  # Reset the current language during operations.
+  graphql.explorer_subscriber:
+    class: Drupal\graphql\EventSubscriber\ExplorerEventSubscriber
+    tags:
+      - { name: event_subscriber }
+
   # Plugin manager for schemas
   plugin.manager.graphql.schema:
     class: Drupal\graphql\Plugin\SchemaPluginManager

--- a/src/EventSubscriber/ExplorerEventSubscriber.php
+++ b/src/EventSubscriber/ExplorerEventSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\graphql\EventSubscriber;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ExplorerEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['bypassValidation'];
+    return $events;
+  }
+
+  /**
+   * Add the bypass_validation url parameter to graphql admin routes.
+   *
+   * @param RequestEvent $event
+   */
+  public function bypassValidation(RequestEvent $event) {
+    $route = \Drupal::routeMatch()->getRouteName();
+
+    // If a bypass_validation param is already set, skip.
+    if ($event->getRequest()->get('bypass_validation')) {
+      return;
+    }
+
+    // Only bypass validation for these two routes.
+    if ($route === 'graphql.explorer' || $route === 'graphql.voyager') {
+      /** @var \Drupal\graphql\Entity\Server $server */
+      $server = $event->getRequest()->get('graphql_server');
+
+      $url = $event->getRequest()->getUri();
+
+      // Get the bypass_validation_token from the server settings.
+      $bypass_validation_token = $server->get('bypass_validation_token');
+
+      // Add the bypass_validation parameter to the current url.
+      $url .= (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . 'bypass_validation=' . $bypass_validation_token;
+
+      // Redirect to the new url.
+      $event->setResponse(new RedirectResponse($url));
+    }
+  }
+}

--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -186,6 +186,39 @@ class ServerForm extends EntityForm {
       '#description' => $this->t('Whether caching of queries and partial results is enabled.'),
     ];
 
+    $form['validation'] = [
+      '#title' => $this->t('Validation rules'),
+      '#type' => 'fieldset',
+    ];
+
+    $form['validation']['disable_introspection'] = [
+      '#title' => $this->t('Disable introspection'),
+      '#type' => 'checkbox',
+      '#default_value' => !!$server->get('disable_introspection'),
+      '#description' => $this->t('Whether introspection should be disabled.'),
+    ];
+
+    $form['validation']['depth'] = [
+      '#title' => $this->t('Max query depth'),
+      '#type' => 'number',
+      '#default_value' => $server->get('depth'),
+      '#description' => $this->t('The maximum allowed depth of nested queries. Leave empty to set unlimited.'),
+    ];
+
+    $form['validation']['complexity'] = [
+      '#title' => $this->t('Max query complexity'),
+      '#default_value' => $server->get('complexity'),
+      '#type' => 'number',
+      '#description' => $this->t('The maximum allowed complexity of a query. Leave empty to set unlimited.'),
+    ];
+
+    $form['validation']['bypass_validation_token'] = [
+      '#title' => $this->t('Bypass validation token'),
+      '#default_value' => $server->get('bypass_validation_token'),
+      '#type' => 'textfield',
+      '#description' => $this->t('A string token that can be used as the "bypass_validation" parameter when doing a GraphQL request. This bypasses the above validation rules. Could be used when generating types for front-end applications.'),
+    ];
+
     $debug_flags = $server->get('debug_flag') ?? 0;
     $form['debug_flag'] = [
       '#title' => $this->t('Debug settings'),


### PR DESCRIPTION
I noticed there isn't a way to set validation rules like disabling introspection or query depth and complexity. Setting these rules can improve the security of your GraphQL endpoint, so I think it's a welcome addition. I've added the rules config to the Server settings form.

I've also added a way of bypassing the rules by using a simple query parameter which can also be set in the Server settings. Bypassing the rules can be useful for codegen scripts or just when developing.

The event subscriber I added is just there to add the bypass query parameter to the URL of the explorer and voyager pages, but I think this can be done better and cleaner.