### PR TITLE
Fix: Exclude conflicting fields

### DIFF
--- a/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schemas/SchemaPluginBase.php
@@ -439,7 +439,13 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
    * {@inheritdoc}
    */
   public function processFields(array $fields) {
-    return array_map([$this, 'buildField'], $fields);
+    $processFields = array_map([$this, 'buildField'], $fields);
+    foreach($processFields as $key => $processField) {
+      if($processField === false) {
+        unset($processFields[$key]);
+      }
+    }
+    return $processFields;
   }
 
   /**
@@ -506,6 +512,13 @@ abstract class SchemaPluginBase extends PluginBase implements SchemaPluginInterf
    *   The field definition.
    */
   protected function buildField($field) {
+    $exceptions = array('layout_section', 'shipment_item');
+    $inArray = in_array($field['definition']['type'][0], $exceptions);
+    
+    if($inArray) {
+      return false;
+    }
+
     if (!isset($this->fields[$field['id']])) {
       $creator = [$field['class'], 'createInstance'];
       $this->fields[$field['id']] = $creator($this, $this->fieldManager, $field['definition'], $field['id']);


### PR DESCRIPTION
It fixes issue #1245, excluding conflicting fields.
I only had issues with those 2 fields, but in case you find more, just add them to the exceptions array. 