### PR TITLE
1251 Symfony 4.4 event dispatcher parameter order change

### DIFF
--- a/src/GraphQL/Execution/Executor.php
+++ b/src/GraphQL/Execution/Executor.php
@@ -274,11 +274,11 @@ class Executor implements ExecutorImplementation {
     );
 
     $event = new OperationEvent($this->context);
-    $this->dispatcher->dispatch(OperationEvent::GRAPHQL_OPERATION_BEFORE, $event);
+    $this->dispatcher->dispatch($event, OperationEvent::GRAPHQL_OPERATION_BEFORE);
 
     return $executor->doExecute()->then(function ($result) {
       $event = new OperationEvent($this->context, $result);
-      $this->dispatcher->dispatch(OperationEvent::GRAPHQL_OPERATION_AFTER, $event);
+      $this->dispatcher->dispatch($event, OperationEvent::GRAPHQL_OPERATION_AFTER);
 
       return $result;
     });


### PR DESCRIPTION
As of Symfony 4.4 the event dispatch parameter order has changed, this fix will prepare the code and change the parameters to the right order