### PR TITLE
#1268: Error when store a big data to cache

### DIFF
--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -177,7 +177,7 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
     $schema = implode("\n\n", $schema);
     // Parsing only to check syntax errors in the current schema.
     $ast = Parser::parse($schema);
-    if (empty($this->inDevelopment) && $ast) {
+    if (empty($this->inDevelopment)) {
       // Caching schema string.
       $this->astCache->set($cid, $schema, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }

--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -174,9 +174,12 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
     });
 
     $schema = array_merge([$this->getSchemaDefinition()], $extensions);
-    $ast = Parser::parse(implode("\n\n", $schema));
-    if (empty($this->inDevelopment)) {
-      $this->astCache->set($cid, $ast, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
+    $schema = implode("\n\n", $schema);
+    // Parsing only to check syntax errors in the current schema.
+    $ast = Parser::parse($schema);
+    if (empty($this->inDevelopment) && $ast) {
+      // Caching schema string.
+      $this->astCache->set($cid, $schema, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }
 
     return $ast;


### PR DESCRIPTION
ISSUE: #1268 Error when store a big data to cache.

This PR Fixes the schema cache issue when your schema reach out certain size.

 - Issue description: when your schema reach certain size the Parsed schema object ( `DocumentNode`) becomes unmanageable by the unserialize function,  leading  to not loading the right cached schema data .
 
 How to do a basic a test:
 - [ ] Apply this patch https://github.com/drupal-graphql/graphql/pull/1272.patch
 - [ ] clear drupals cache ( `drush cr` )
 - [ ] load the graphql explorer page `admin/config/graphql/servers/manage/[SERVER-ID]/explorer` 
 - [ ] It should load without any issues 
 - [ ] Now reload the explorer page, it should keep working as expected.
 