### PR TITLE
test(drupal): Switch to Drupal core 9.4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -85,7 +85,7 @@ jobs:
         run: composer --no-interaction --no-progress require \
           webonyx/graphql-php:^14.8 \
           drupal/typed_data:^1.0 \
-          phpstan/phpstan:^1.4.6 \
+          phpstan/phpstan:^1.7.14 \
           mglaman/phpstan-drupal:^1.1.2 \
           phpstan/phpstan-deprecation-rules:^1.0.0 \
           jangregor/phpstan-prophecy:^1.0.0 \

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,12 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0']
         drupal-core: ['9.4.x']
+        phpstan: ['0']
         include:
+          # We only need to run PHPStan once on the latest PHP version.
+          - php-versions: '8.1'
+            drupal-core: '9.4.x'
+            phpstan: '1'
           # Extra run to also test on latest Drupal 10 and PHP 8.1.
           - php-versions: '8.1'
             drupal-core: '10.0.x'
+            phpstan: '0'
     steps:
       - name: Checkout Drupal core
         uses: actions/checkout@v2
@@ -103,8 +109,7 @@ jobs:
           SIMPLETEST_DB: "sqlite://localhost/:memory:"
 
       - name: Run PHPStan
-        run: |
-          cd modules/graphql && ../../vendor/bin/phpstan analyse
+        run: if [[ ${{ matrix.phpstan }} == "1" ]]; then cd modules/graphql && ../../vendor/bin/phpstan analyse; fi
 
       - name: Run PHPCS
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.3', '7.4', '8.0', '8.1']
-        drupal-core: ['9.3.x']
+        drupal-core: ['9.4.x']
         include:
           # Extra run to also test on latest Drupal 10 and PHP 8.1.
           - php-versions: '8.1'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,19 +6,18 @@ parameters:
   customRulesetUsed: true
   paths:
     - .
-  # We test with PHPStan on Drupal 8 and 9 and might have different ignored
-  # errors on both.
-  reportUnmatchedIgnoredErrors: false
   # We inherit a lot of Drupal core docs that don't specify iterable types on
   # arrays, not sure we can fix this in a good way.
   checkMissingIterableValueType: false
   # Not sure we can specify generic types properly with Drupal coding standards
   # yet, disable for now.
   checkGenericClassInNonGenericObjectType: false
-  # Exclude the RouteLoad producer because the redirect module is not D10
-  # compatible so we are not downloading it.
   excludePaths:
+    # Exclude the RouteLoad producer because the redirect module is not D10
+    # compatible so we are not downloading it.
     - src/Plugin/GraphQL/DataProducer/Routing/RouteLoad.php
+    # This file only exists for Drupal 10 compatibility, ignore it for now.
+    - tests/src/Traits/CompatibleLoggerTrait10.php
   ignoreErrors:
     # @todo Ignore phpstan-drupal extension's rules for now, activate later.
     - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
@@ -38,35 +37,9 @@ parameters:
       message: "#^Method Drupal\\\\graphql\\\\Plugin\\\\LanguageNegotiation\\\\OperationLanguageNegotiation\\:\\:getLangcode\\(\\) should return string but returns false\\.$#"
       count: 1
       path: src/Plugin/LanguageNegotiation/OperationLanguageNegotiation.php
-    - "#^Parameter .+ of method Drupal\\\\Core\\\\Entity\\\\Query\\\\QueryInterface\\:\\:range\\(\\) expects null, int given\\.$#"
     # We forgot to use return type hints on some interfaces, cannot be changed
     # in stable 4.0.
     # @todo use return type hints everywhere for 5.0.
-    -
-      message: "#^Method Drupal\\\\graphql\\\\Entity\\\\ServerInterface\\:\\:addPersistedQueryInstance\\(\\) has no return typehint specified\\.$#"
-      count: 1
-      path: src/Entity/ServerInterface.php
-
-    -
-      message: "#^Method Drupal\\\\graphql\\\\Entity\\\\ServerInterface\\:\\:removePersistedQueryInstance\\(\\) has no return typehint specified\\.$#"
-      count: 1
-      path: src/Entity/ServerInterface.php
-
-    -
-      message: "#^Method Drupal\\\\graphql\\\\Entity\\\\ServerInterface\\:\\:removeAllPersistedQueryInstances\\(\\) has no return typehint specified\\.$#"
-      count: 1
-      path: src/Entity/ServerInterface.php
-
-    -
-      message: "#^Method Drupal\\\\graphql\\\\Plugin\\\\PersistedQueryPluginInterface\\:\\:setWeight\\(\\) has no return typehint specified\\.$#"
-      count: 1
-      path: src/Plugin/PersistedQueryPluginInterface.php
-
-    -
-      message: "#^Method Drupal\\\\graphql\\\\Plugin\\\\SchemaExtensionPluginInterface\\:\\:registerResolvers\\(\\) has no return typehint specified\\.$#"
-      count: 1
-      path: src/Plugin/SchemaExtensionPluginInterface.php
-
     -
       message: "#^Method Drupal\\\\graphql\\\\Plugin\\\\PersistedQueryPluginInterface\\:\\:setWeight\\(\\) has no return type specified\\.$#"
       count: 1
@@ -91,8 +64,3 @@ parameters:
       message: "#^Method Drupal\\\\graphql\\\\Entity\\\\ServerInterface\\:\\:removePersistedQueryInstance\\(\\) has no return type specified\\.$#"
       count: 1
       path: src/Entity/ServerInterface.php
-
-    -
-      message: "#^Unable to resolve the template type ExpectedType in call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\)$#"
-      count: 1
-      path: tests/src/Kernel/ResolverBuilderTest.php

--- a/tests/src/Kernel/Framework/LoggerTest.php
+++ b/tests/src/Kernel/Framework/LoggerTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\graphql\Kernel\Framework;
 
-use Drupal\Core\Logger\RfcLoggerTrait;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql\Traits\CompatibleLoggerTrait;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -13,14 +13,7 @@ use Psr\Log\LoggerInterface;
  */
 class LoggerTest extends GraphQLTestBase implements LoggerInterface {
 
-  use RfcLoggerTrait;
-
-  /**
-   * Loggers calls.
-   *
-   * @var array
-   */
-  protected $loggerCalls = [];
+  use CompatibleLoggerTrait;
 
   /**
    * {@inheritdoc}
@@ -48,17 +41,6 @@ GQL;
     $this->mockResolver('Query', 'takesIntArgument');
 
     $this->container->get('logger.factory')->addLogger($this);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function log($level, $message, array $context = []) {
-    $this->loggerCalls[] = [
-      'level' => $level,
-      'message' => $message,
-      'context' => $context,
-    ];
   }
 
   /**

--- a/tests/src/Traits/CompatibleLoggerTrait.php
+++ b/tests/src/Traits/CompatibleLoggerTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\graphql\Traits;
+
+use Drupal\Core\Logger\RfcLoggerTrait;
+
+if (version_compare(\Drupal::VERSION, '10.0.0') >= 0) {
+  eval(<<<'CODE'
+  trait CompatibleLoggerTrait {
+    use RfcLoggerTrait;
+
+    /**
+     * Collected loggers calls.
+     *
+     * @var array
+     */
+    protected $loggerCalls = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void {
+      $this->loggerCalls[] = [
+        'level' => $level,
+        'message' => $message,
+        'context' => $context,
+      ];
+    }
+
+  }
+CODE);
+}
+else {
+  trait CompatibleLoggerTrait {
+    use RfcLoggerTrait;
+
+    /**
+     * Collected loggers calls.
+     *
+     * @var array
+     */
+    protected $loggerCalls = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = []) {
+      $this->loggerCalls[] = [
+        'level' => $level,
+        'message' => $message,
+        'context' => $context,
+      ];
+    }
+
+  }
+}

--- a/tests/src/Traits/CompatibleLoggerTrait.php
+++ b/tests/src/Traits/CompatibleLoggerTrait.php
@@ -4,9 +4,13 @@ namespace Drupal\Tests\graphql\Traits;
 
 use Drupal\Core\Logger\RfcLoggerTrait;
 
+// The logger trait has a different function signature in Drupal 10, so we need
+// this hack to register a compatible trait for both Drupal 9 and 10.
 [$version] = explode('.', \Drupal::VERSION, 2);
 if ($version >= 10) {
   eval(<<<'CODE'
+  use Drupal\Core\Logger\RfcLoggerTrait;
+
   trait CompatibleLoggerTrait {
     use RfcLoggerTrait;
 

--- a/tests/src/Traits/CompatibleLoggerTrait.php
+++ b/tests/src/Traits/CompatibleLoggerTrait.php
@@ -8,33 +8,7 @@ use Drupal\Core\Logger\RfcLoggerTrait;
 // this hack to register a compatible trait for both Drupal 9 and 10.
 [$version] = explode('.', \Drupal::VERSION, 2);
 if ($version >= 10) {
-  // phpcs:ignore
-  eval(<<<'CODE'
-  use Drupal\Core\Logger\RfcLoggerTrait;
-
-  trait CompatibleLoggerTrait {
-    use RfcLoggerTrait;
-
-    /**
-     * Collected loggers calls.
-     *
-     * @var array
-     */
-    protected $loggerCalls = [];
-
-    /**
-     * {@inheritdoc}
-     */
-    public function log($level, string|\Stringable $message, array $context = []): void {
-      $this->loggerCalls[] = [
-        'level' => $level,
-        'message' => $message,
-        'context' => $context,
-      ];
-    }
-
-  }
-CODE);
+  require_once __DIR__ . '/CompatibleLoggerTrait10.php';
 }
 else {
   /**

--- a/tests/src/Traits/CompatibleLoggerTrait.php
+++ b/tests/src/Traits/CompatibleLoggerTrait.php
@@ -8,6 +8,7 @@ use Drupal\Core\Logger\RfcLoggerTrait;
 // this hack to register a compatible trait for both Drupal 9 and 10.
 [$version] = explode('.', \Drupal::VERSION, 2);
 if ($version >= 10) {
+  // phpcs:ignore
   eval(<<<'CODE'
   use Drupal\Core\Logger\RfcLoggerTrait;
 
@@ -36,6 +37,9 @@ if ($version >= 10) {
 CODE);
 }
 else {
+  /**
+   * Drupal 9 compatible.
+   */
   trait CompatibleLoggerTrait {
     use RfcLoggerTrait;
 

--- a/tests/src/Traits/CompatibleLoggerTrait.php
+++ b/tests/src/Traits/CompatibleLoggerTrait.php
@@ -4,7 +4,8 @@ namespace Drupal\Tests\graphql\Traits;
 
 use Drupal\Core\Logger\RfcLoggerTrait;
 
-if (version_compare(\Drupal::VERSION, '10.0.0') >= 0) {
+[$version] = explode('.', \Drupal::VERSION, 2);
+if ($version >= 10) {
   eval(<<<'CODE'
   trait CompatibleLoggerTrait {
     use RfcLoggerTrait;

--- a/tests/src/Traits/CompatibleLoggerTrait10.php
+++ b/tests/src/Traits/CompatibleLoggerTrait10.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\Tests\graphql\Traits;
+
+use Drupal\Core\Logger\RfcLoggerTrait;
+
+/**
+ * Drupal 10 compatible.
+ */
+// phpcs:ignore
+trait CompatibleLoggerTrait {
+  use RfcLoggerTrait;
+
+  /**
+   * Collected loggers calls.
+   *
+   * @var array
+   */
+  protected $loggerCalls = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  // phpcs:ignore
+  public function log($level, string|\Stringable $message, array $context = []): void {
+    $this->loggerCalls[] = [
+      'level' => $level,
+      'message' => $message,
+      'context' => $context,
+    ];
+  }
+
+}


### PR DESCRIPTION
Switching to testing with the most recent Drupal 9.4 version. Also fixing Drupal 10 testing, which requires a hack to work around changed function signatures.