### PR TITLE
fix(routing): Reworks routing to rely on the internal upcasting and provides config overrides for the server entity in routes.

### DIFF
--- a/graphql.routing.yml
+++ b/graphql.routing.yml
@@ -48,8 +48,8 @@ graphql.explorer:
   options:
     _admin_route: TRUE
     parameters:
-      server:
-        type: entity:graphql_server
+      graphql_server:
+        with_config_overrides: TRUE
 
 graphql.voyager:
   path: '/admin/config/graphql/servers/manage/{graphql_server}/voyager'
@@ -62,7 +62,7 @@ graphql.voyager:
     _admin_route: TRUE
     parameters:
       graphql_server:
-        type: entity:graphql_server
+        with_config_overrides: TRUE
 
 graphql.validate:
   path: '/admin/config/graphql/servers/manage/{graphql_server}/validate'
@@ -75,8 +75,7 @@ graphql.validate:
     _admin_route: TRUE
     parameters:
       graphql_server:
-        type: entity:graphql_server
-
+        with_config_overrides: TRUE
 
 entity.graphql_server.delete_form:
   path: '/admin/config/graphql/servers/manage/{graphql_server}/delete'


### PR DESCRIPTION
### Issues:

- When I tried to disable introspection locally I faced an issue that it is working for the GraphQL Explorer, this is an inconsistency. Because, it isn't working when you call it outside Drupal, but is working inside Drupal. Whenever the introspection is disabled either in the UI or using config overrides it should not work in the GraphQL Explorer.
After closer debugging, I found out that routing provides Server entity without overrides of configs. A similar issue in the `search _api` - https://www.drupal.org/project/search_api/issues/2690373. 
- After checking `graphql.routing.yml` I found out that we're using route param conversion, which isn't necessary if the param and entity machine name is identical and handled by the internal Drupal logic. See https://www.drupal.org/docs/8/api/routing-system/parameters-in-routes/how-upcasting-parameters-works

### Settings example
```
// Disable introspection.
$config['graphql.graphql_servers.example_schema']['disable_introspection'] = TRUE;
```

### Proposal
- Clean up `graphql.routing.yml` and remove unnecessary routing param conversion.
- Add `with_config_overrides: TRUE` to every route using the needed parameters.

### Scope:

- Removes unnecessary params conversion as entity name used and is working due to the internal upcasting logic.
- Provides for the explorer, voyager, validate routes config overrides entities in order to have consistency.
