### PR TITLE
feat(DataProducer): make sure Weight returns int

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/Weight.php
+++ b/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/Weight.php
@@ -49,7 +49,7 @@ class Weight extends DataProducerPluginBase {
       $field_id = $entity_definition_field->getName();
 
       if (isset($content[$field_id])) {
-        return $content[$field_id]['weight'];
+        return (int) $content[$field_id]['weight'];
       }
       else {
         return 0;


### PR DESCRIPTION
Implicit conversion fo float to int generates warning in PHP 8.1
e.g.:
<em class="placeholder">Deprecated function</em>: Implicit conversion from float 2.5 to int loses precision in <em class="placeholder">Drupal\graphql\Plugin\GraphQL\DataProducer\EntityDefinition\Fields\Weight-&gt;resolve()</em> (line <em class="placeholder">52</em> of <em class="placeholder">/var/www/html/backend/web/modules/contrib/graphql/src/Plugin/GraphQL/DataProducer/EntityDefinition/Fields/Weight.php</em>)