### PR TITLE
Added condition in graphql.install for non empty variable

### DIFF
--- a/graphql.install
+++ b/graphql.install
@@ -37,10 +37,12 @@ function graphql_uninstall(): void {
   $configFactory = \Drupal::getContainer()->get('config.factory');
   $languageTypes = $configFactory->getEditable('language.types');
   $negotiation = $languageTypes->get('negotiation');
-  foreach (array_keys($negotiation) as $type) {
-    unset($negotiation[$type]['enabled']['language-graphql']);
+  if (!empty($negotiation)) {
+    foreach (array_keys($negotiation) as $type) {
+      unset($negotiation[$type]['enabled']['language-graphql']);
+    }
+    $languageTypes->set('negotiation', $negotiation)->save();
   }
-  $languageTypes->set('negotiation', $negotiation)->save();
 }
 
 /**

--- a/graphql.install
+++ b/graphql.install
@@ -36,10 +36,10 @@ function graphql_uninstall(): void {
   /** @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory */
   $configFactory = \Drupal::getContainer()->get('config.factory');
   $languageTypes = $configFactory->getEditable('language.types');
-  $negotiation = $languageTypes->get('negotiation');
-  if (!empty($negotiation)) {
+  if (!$languageTypes->isNew()) {
+    $negotiation = $languageTypes->get('negotiation');
     foreach (array_keys($negotiation) as $type) {
-      unset($negotiation[$type]['enabled']['language-graphql']);
+        unset($negotiation[$type]['enabled']['language-graphql']);
     }
     $languageTypes->set('negotiation', $negotiation)->save();
   }


### PR DESCRIPTION
Context:

1. Install Drupal in (standard install profile)
2. Install graphQL module
3. Uninstall GraphQL module and see error
```
 ---- -------------- -------- ---------- -------------------------------------- 
  ID   Date           Type     Severity   Message                               
 ---- -------------- -------- ---------- -------------------------------------- 
  46   04/Jul 15:32   php      Error      TypeError: array_keys(): Argument #1  
                                          ($array) must be of type array, null  
                                          given in array_keys() (line 40 of     
                                          /var/www/html/web/modules/contrib/gr  
                                          aphql/graphql.install).   
```        

This PR adds an 'if' condition in graphql.install to check if language module is correctly enabled