### PR TITLE
fix: allow big schemas to be serialized and cached

### DIFF
--- a/src/Plugin/GraphQL/Schema/AlterableComposableSchema.php
+++ b/src/Plugin/GraphQL/Schema/AlterableComposableSchema.php
@@ -130,7 +130,7 @@ class AlterableComposableSchema extends ComposableSchema {
       $event,
       AlterSchemaDataEvent::EVENT_NAME
     );
-    $ast = Parser::parse(implode("\n\n", $event->getSchemaData()));
+    $ast = Parser::parse(implode("\n\n", $event->getSchemaData()), ['noLocation' => TRUE]);
     if (empty($this->inDevelopment)) {
       $this->astCache->set($cid, $ast, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }
@@ -172,7 +172,7 @@ class AlterableComposableSchema extends ComposableSchema {
       $event,
       AlterSchemaExtensionDataEvent::EVENT_NAME
     );
-    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $event->getSchemaExtensionData())) : NULL;
+    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $event->getSchemaExtensionData()), ['noLocation' => TRUE]) : NULL;
     if (empty($this->inDevelopment)) {
       $this->astCache->set($cid, $ast, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }

--- a/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
+++ b/src/Plugin/GraphQL/Schema/SdlSchemaPluginBase.php
@@ -174,7 +174,7 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
     });
 
     $schema = array_merge([$this->getSchemaDefinition()], $extensions);
-    $ast = Parser::parse(implode("\n\n", $schema));
+    $ast = Parser::parse(implode("\n\n", $schema), ['noLocation' => TRUE]);
     if (empty($this->inDevelopment)) {
       $this->astCache->set($cid, $ast, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }
@@ -205,7 +205,7 @@ abstract class SdlSchemaPluginBase extends PluginBase implements SchemaPluginInt
       return !empty($definition);
     });
 
-    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $extensions)) : NULL;
+    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $extensions), ['noLocation' => TRUE]) : NULL;
     if (empty($this->inDevelopment)) {
       $this->astCache->set($cid, $ast, CacheBackendInterface::CACHE_PERMANENT, ['graphql']);
     }


### PR DESCRIPTION
Fixes https://github.com/drupal-graphql/graphql/issues/1268 using `noLocation` option suggested in https://github.com/webonyx/graphql-php/issues/1164#issuecomment-1149891560