### PR TITLE
Calling Request::getSession() without having a session is deprecated

### DIFF
--- a/src/GraphQL/Buffers/SubRequestBuffer.php
+++ b/src/GraphQL/Buffers/SubRequestBuffer.php
@@ -104,10 +104,10 @@ class SubRequestBuffer extends BufferBase {
       }, $buffer);
     });
 
-    if ($session = $current->getSession()) {
-      $request->setSession($session);
+    if ($current->hasSession()) {
+      $request->setSession($current->getSession());
     }
-    
+
     return $request;
   }
 


### PR DESCRIPTION
Fixes #1369