### PR TITLE
Set language label in test

### DIFF
--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -82,13 +82,13 @@ abstract class GraphQLTestBase extends KernelTestBase {
     ConfigurableLanguage::create([
       'id' => 'fr',
       'weight' => 1,
-      'label' => 'french',                    
+      'label' => 'french',
     ])->save();
 
     ConfigurableLanguage::create([
       'id' => 'de',
       'weight' => 2,
-      'label' => 'german', 
+      'label' => 'german',
     ])->save();
 
     $this->builder = new ResolverBuilder();

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -82,11 +82,13 @@ abstract class GraphQLTestBase extends KernelTestBase {
     ConfigurableLanguage::create([
       'id' => 'fr',
       'weight' => 1,
+      'label' => 'french',                    
     ])->save();
 
     ConfigurableLanguage::create([
       'id' => 'de',
       'weight' => 2,
+      'label' => 'german', 
     ])->save();
 
     $this->builder = new ResolverBuilder();

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -88,7 +88,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
     ConfigurableLanguage::create([
       'id' => 'de',
       'weight' => 2,
-      'label' => 'german',
+      'label' => 'German',
     ])->save();
 
     $this->builder = new ResolverBuilder();

--- a/tests/src/Kernel/GraphQLTestBase.php
+++ b/tests/src/Kernel/GraphQLTestBase.php
@@ -82,7 +82,7 @@ abstract class GraphQLTestBase extends KernelTestBase {
     ConfigurableLanguage::create([
       'id' => 'fr',
       'weight' => 1,
-      'label' => 'french',
+      'label' => 'French',
     ])->save();
 
     ConfigurableLanguage::create([


### PR DESCRIPTION
We are getting schema validation errors in Thunder with Drupal 10.2

See https://github.com/thunder/thunder-distribution/actions/runs/7274072144/job/19819383787#step:11:147