### PR TITLE
 drupal-graphql#1322: Fix fatal error when attempting to load an entity for a language the entity is not translated into.

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -172,6 +172,9 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
 
       // Get the correct translation.
       if (isset($language) && $language !== $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+        if (!$entity->hasTranslation($language)) {
+          return NULL;
+        }
         $entity = $entity->getTranslation($language);
         $entity->addCacheContexts(["static:language:{$language}"]);
       }

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -165,6 +165,9 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
 
       // Get the correct translation.
       if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+        if (!$entity->hasTranslation($language)) {
+          return NULL;
+        }
         $entity = $entity->getTranslation($language);
         $entity->addCacheContexts(["static:language:{$language}"]);
       }

--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
@@ -126,6 +126,9 @@ class RouteEntity extends DataProducerPluginBase implements ContainerFactoryPlug
 
         // Get the correct translation.
         if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+          if (!$entity->hasTranslation($language)) {
+            return NULL;
+          }
           $entity = $entity->getTranslation($language);
           $entity->addCacheContexts(["static:language:{$language}"]);
         }


### PR DESCRIPTION
If an entity is requested directly with a translation that it does not yet have, currently we see a fatal error, because the code tries to load the entity translation before checking for its existence.

This was noted by @artemvd in https://github.com/drupal-graphql/graphql/issues/1322. 

The PR that was created #1323   didn't fix the issue in two additional plugins, this PR does, by adding the same code.