### PR TITLE
refactor(druapl9): Drop Drupal 9 support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,18 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
-        # Keep testing Drupal 9 untill 6 months after it got unsupported, so
-        # untill May 1st 2024.
-        drupal-core: ['9.5.x']
+        php-versions: ['8.1', '8.2']
+        drupal-core: ['10.2.x']
         phpstan: ['0']
         include:
-          # Extra runs to also test on latest Drupal 10.
+          # Extra run to test older supported Drupal 10.1.x.
           - php-versions: '8.1'
-            drupal-core: '10.2.x'
-            phpstan: '0'
-          - php-versions: '8.2'
-            drupal-core: '10.2.x'
+            drupal-core: '10.1.x'
             phpstan: '0'
           # We only need to run PHPStan once on the latest PHP version.
           - php-versions: '8.3'

--- a/examples/graphql_composable/graphql_composable.info.yml
+++ b/examples/graphql_composable/graphql_composable.info.yml
@@ -5,4 +5,4 @@ package: GraphQL
 dependencies:
   - graphql:graphql
   - node:node
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10.1

--- a/examples/graphql_example/graphql_examples.info.yml
+++ b/examples/graphql_example/graphql_examples.info.yml
@@ -5,4 +5,4 @@ package: GraphQL
 dependencies:
   - graphql:graphql
   - node:node
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10.1

--- a/graphql.info.yml
+++ b/graphql.info.yml
@@ -3,6 +3,6 @@ type: module
 description: 'Base module for integrating GraphQL with Drupal.'
 package: GraphQL
 configure: graphql.config_page
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10.1
 dependencies:
   - typed_data:typed_data

--- a/src/GraphQL/Execution/Executor.php
+++ b/src/GraphQL/Execution/Executor.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\graphql\GraphQL\Execution;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheBackendInterface;
@@ -22,7 +23,6 @@ use GraphQL\Type\Schema;
 use GraphQL\Utils\AST;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Executes GraphQL queries with cache lookup.
@@ -51,11 +51,9 @@ class Executor implements ExecutorImplementation {
   protected $contextsManager;
 
   /**
-   * The request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
+   * The date/time service.
    */
-  protected $requestStack;
+  protected TimeInterface $time;
 
   /**
    * The event dispatcher.
@@ -127,8 +125,8 @@ class Executor implements ExecutorImplementation {
    *   The cache contexts manager service.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cacheBackend
    *   The cache backend for caching query results.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-   *   The request stack.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The date/time service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
    *   The event dispatcher.
    * @param \GraphQL\Executor\Promise\PromiseAdapter $adapter
@@ -143,7 +141,7 @@ class Executor implements ExecutorImplementation {
   public function __construct(
     CacheContextsManager $contextsManager,
     CacheBackendInterface $cacheBackend,
-    RequestStack $requestStack,
+    TimeInterface $time,
     EventDispatcherInterface $dispatcher,
     PromiseAdapter $adapter,
     Schema $schema,
@@ -156,7 +154,7 @@ class Executor implements ExecutorImplementation {
   ) {
     $this->contextsManager = $contextsManager;
     $this->cacheBackend = $cacheBackend;
-    $this->requestStack = $requestStack;
+    $this->time = $time;
     $this->dispatcher = $dispatcher;
 
     $this->adapter = $adapter;
@@ -198,7 +196,7 @@ class Executor implements ExecutorImplementation {
     return new static(
       $container->get('cache_contexts_manager'),
       $container->get('cache.graphql.results'),
-      $container->get('request_stack'),
+      $container->get('datetime.time'),
       $container->get('event_dispatcher'),
       $adapter,
       $schema,
@@ -444,8 +442,7 @@ class Executor implements ExecutorImplementation {
    * @see \Drupal\Core\Cache\CacheBackendInterface::set()
    */
   protected function maxAgeToExpire($maxAge) {
-    // @todo Can be removed when D9 support is dropped.
-    $time = $this->requestStack->getMainRequest()->server->get('REQUEST_TIME');
+    $time = $this->time->getRequestTime();
     return ($maxAge === Cache::PERMANENT) ? Cache::PERMANENT : (int) $time + $maxAge;
   }
 

--- a/src/GraphQL/Utility/FileUpload.php
+++ b/src/GraphQL/Utility/FileUpload.php
@@ -17,7 +17,6 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Utility\Token;
 use Drupal\file\FileInterface;
@@ -194,9 +193,13 @@ class FileUpload {
     switch ($uploaded_file->getError()) {
       case UPLOAD_ERR_INI_SIZE:
       case UPLOAD_ERR_FORM_SIZE:
+        // @todo Drupal 10.1 compatibility, needs to be converted to
+        // ByteSizeMarkup later.
+        // @phpstan-ignore-next-line
+        $maxUploadSize = format_size($this->getMaxUploadSize($settings));
         $response->addViolation($this->t('The file @file could not be saved because it exceeds @maxsize, the maximum allowed size for uploads.', [
           '@file' => $uploaded_file->getClientOriginalName(),
-          '@maxsize' => ByteSizeMarkup::create($this->getMaxUploadSize($settings)),
+          '@maxsize' => $maxUploadSize,
         ]));
         return $response;
 

--- a/src/GraphQL/Utility/FileUpload.php
+++ b/src/GraphQL/Utility/FileUpload.php
@@ -17,6 +17,7 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Utility\Token;
 use Drupal\file\FileInterface;
@@ -193,13 +194,9 @@ class FileUpload {
     switch ($uploaded_file->getError()) {
       case UPLOAD_ERR_INI_SIZE:
       case UPLOAD_ERR_FORM_SIZE:
-        // @todo Drupal 9 compatibility, needs to be converted to ByteSizeMarkup
-        // later.
-        // @phpstan-ignore-next-line
-        $maxUploadSize = format_size($this->getMaxUploadSize($settings));
         $response->addViolation($this->t('The file @file could not be saved because it exceeds @maxsize, the maximum allowed size for uploads.', [
           '@file' => $uploaded_file->getClientOriginalName(),
-          '@maxsize' => $maxUploadSize,
+          '@maxsize' => ByteSizeMarkup::create($this->getMaxUploadSize($settings)),
         ]));
         return $response;
 
@@ -271,7 +268,7 @@ class FileUpload {
       $file->setSize(@filesize($temp_file_path));
 
       // Validate against file_validate() first with the temporary path.
-      // @todo Drupal 9 compatibility, needs to be converted to file validate
+      // @todo Drupal 10.1 compatibility, needs to be converted to file validate
       // service later.
       // @phpstan-ignore-next-line
       $errors = file_validate($file, $validators);
@@ -505,7 +502,7 @@ class FileUpload {
           /** @var \Drupal\file\FileInterface $file */
           $file = $this->fileStorage->create([]);
           $file->setFilename($filename);
-          // @todo Drupal 9 compatibility, needs to be converted to file
+          // @todo Drupal 10.1 compatibility, needs to be converted to file
           // validator service later.
           // @phpstan-ignore-next-line
           $passes_validation = empty(file_validate_extensions($file, $validators['file_validate_extensions'][0]));

--- a/src/Routing/QueryRouteEnhancer.php
+++ b/src/Routing/QueryRouteEnhancer.php
@@ -136,9 +136,7 @@ class QueryRouteEnhancer implements EnhancerInterface {
       // Allow other origins as configured in the CORS policy.
       if (!empty($this->corsOptions['enabled'])) {
         $cors_service = new CorsService($this->corsOptions);
-        // Drupal 9 compatibility, method name has changed in Drupal 10.
-        // @phpstan-ignore-next-line
-        if ($cors_service->isActualRequestAllowed($request)) {
+        if ($cors_service->isOriginAllowed($request)) {
           return;
         }
       }

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -496,6 +496,11 @@ GQL;
         'entity_form_display_context' => $builder->fromContext('entity_form_display'),
       ])
     );
+
+    // @todo Different description between Drupal 10.1 and 10.2, can be removed
+    // when Drupal 10.1 support is dropped.
+    $this->fullDefinitionResult['entityDefinition']['fields'][11]['description'] =
+      $this->container->get('entity_field.manager')->getBaseFieldDefinitions('node')['created']->getDescription();
   }
 
   /**

--- a/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
+++ b/tests/src/Kernel/DataProducer/EntityDefinitionTest.php
@@ -496,11 +496,6 @@ GQL;
         'entity_form_display_context' => $builder->fromContext('entity_form_display'),
       ])
     );
-
-    // @todo Different description between Drupal 9 and 10, can be removed when
-    // Drupal 9 support is dropped.
-    $this->fullDefinitionResult['entityDefinition']['fields'][11]['description'] =
-      $this->container->get('entity_field.manager')->getBaseFieldDefinitions('node')['created']->getDescription();
   }
 
   /**

--- a/tests/src/Kernel/DataProducer/EntityReferenceTest.php
+++ b/tests/src/Kernel/DataProducer/EntityReferenceTest.php
@@ -5,8 +5,32 @@ namespace Drupal\Tests\graphql\Kernel\DataProducer;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+
+// @todo Drupal 10.1 compatibility: use the deprecated trait for Drupal 10.1.
+if (strpos(\Drupal::VERSION, '10.1') === 0) {
+
+  /**
+   * Helper trait for compatibility with Drupal 9.
+   *
+   * @phpcs:disable Drupal.Classes.ClassFileName.NoMatch
+   */
+  trait EntityReferenceFieldCreationTrait {
+    // @phpstan-ignore-next-line
+    use \Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+
+  }
+}
+else {
+
+  /**
+   * Helper trait for compatibility with Drupal 10.
+   */
+  trait EntityReferenceFieldCreationTrait {
+    use \Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+
+  }
+}
 
 /**
  * Tests the entity_reference data producers.

--- a/tests/src/Kernel/DataProducer/EntityReferenceTest.php
+++ b/tests/src/Kernel/DataProducer/EntityReferenceTest.php
@@ -5,32 +5,8 @@ namespace Drupal\Tests\graphql\Kernel\DataProducer;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
-
-// @todo Drupal 9 compatibility: use the deprecated trait for Drupal 9.
-if (strpos(\Drupal::VERSION, '9') === 0) {
-
-  /**
-   * Helper trait for compatibility with Drupal 9.
-   *
-   * @phpcs:disable Drupal.Classes.ClassFileName.NoMatch
-   */
-  trait EntityReferenceFieldCreationTrait {
-    // @phpstan-ignore-next-line
-    use \Drupal\Tests\field\Traits\EntityReferenceTestTrait;
-
-  }
-}
-else {
-
-  /**
-   * Helper trait for compatibility with Drupal 10.
-   */
-  trait EntityReferenceFieldCreationTrait {
-    use \Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
-
-  }
-}
 
 /**
  * Tests the entity_reference data producers.


### PR DESCRIPTION
Our promise is to support Drupal 9 until May 1st 2024, so we can prepare dropping it.

I decided that the API change to Executor.php is acceptable, since I don't know of any module that would rely on this.