### PR TITLE
AlterableComposableSchema::getExtensionDocument returning NULL #1395

### DIFF
--- a/src/Plugin/GraphQL/Schema/AlterableComposableSchema.php
+++ b/src/Plugin/GraphQL/Schema/AlterableComposableSchema.php
@@ -169,7 +169,8 @@ class AlterableComposableSchema extends ComposableSchema {
       $event,
       AlterSchemaExtensionDataEvent::EVENT_NAME
     );
-    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $event->getSchemaExtensionData()), ['noLocation' => TRUE]) : NULL;
+    $extensions = array_filter($event->getSchemaExtensionData());
+    $ast = !empty($extensions) ? Parser::parse(implode("\n\n", $extensions), ['noLocation' => TRUE]) : NULL;
 
     // No AST caching here as that will be done in getFullSchemaDocument().
     return $ast;

--- a/tests/modules/graphql_alterable_schema_test/src/EventSubscriber/GraphQlSubscriber.php
+++ b/tests/modules/graphql_alterable_schema_test/src/EventSubscriber/GraphQlSubscriber.php
@@ -33,7 +33,18 @@ class GraphQlSubscriber implements EventSubscriberInterface {
     $schemaData = $event->getSchemaExtensionData();
     // I do not recommend direct replace, better user parsing or regex.
     // But this is an example of what you can do.
-    $schemaData['graphql_alterable_schema_test'] = str_replace('position: Int', 'position: Int!', $schemaData['graphql_alterable_schema_test']);
+    $schemaData['graphql_alterable_schema_test'] = str_replace('position: Int', 'position: Int!', $schemaData['graphql_alterable_schema_test'] ?? '');
+
+    // Test empty extensions can still extend the schema.
+    // https://github.com/drupal-graphql/graphql/issues/1395
+    if (empty($schemaData['graphql_alterable_schema_test'])) {
+      $schemaData['graphql_alterable_schema_test'] = <<<GQL
+        extend type Result {
+          empty: Boolean!
+        }
+      GQL;
+    }
+
     $event->setSchemaExtensionData($schemaData);
   }
 


### PR DESCRIPTION
GraphQL 4.x
AlterableComposableSchema

If you have a schema without any extensions, and you use the `AlterSchemaExtensionDataEvent` to add to `$extensions`, the `$ast` will always return `NULL`.

Closes: https://github.com/drupal-graphql/graphql/issues/1395