### PR TITLE
Deprecated NULL placeholder value #1401

### DIFF
--- a/src/Form/ServerForm.php
+++ b/src/Form/ServerForm.php
@@ -100,7 +100,7 @@ class ServerForm extends EntityForm {
     // the first schema that is defined.
     $schema = ($input['schema'] ?? $server->get('schema')) ?: reset($schema_keys);
 
-    if ($this->operation == 'add') {
+    if ($this->operation == 'create') {
       $form['#title'] = $this->t('Add server');
     }
     else {


### PR DESCRIPTION
`$this->operation` is `create`, not `add`

Which passes down a NULL to `$this->t()`'s variable as `$server->label()`

Closes https://github.com/drupal-graphql/graphql/issues/1401