### PR TITLE
fix(dataproducer): Populate context default values before resolving

### DIFF
--- a/config/install/graphql.settings.yml
+++ b/config/install/graphql.settings.yml
@@ -1,0 +1,1 @@
+dataproducer_populate_default_values: true

--- a/config/schema/graphql.schema.yml
+++ b/config/schema/graphql.schema.yml
@@ -66,3 +66,13 @@ graphql.default_persisted_query_configuration:
 
 plugin.plugin_configuration.persisted_query.*:
   type: graphql.default_persisted_query_configuration
+
+graphql.settings:
+  type: config_object
+  label: "GraphQL Settings"
+  mapping:
+    # @todo Remove in GraphQL 5.
+    dataproducer_populate_default_values:
+      type: boolean
+      label: "Populate dataproducer context default values"
+      description: "Legacy setting: Populate dataproducer context default values before executing the resolve method. Set this to true to be future-proof. This setting is deprecated and will be removed in a future release."

--- a/graphql.install
+++ b/graphql.install
@@ -69,3 +69,15 @@ function graphql_update_8001(): void {
  */
 function graphql_update_8400() :void {
 }
+
+/**
+ * Preserve dataproducer default value behavior for old installations.
+ *
+ * Set dataproducer_populate_default_values to TRUE after you verified that your
+ * dataproducers are still working with the new default value behavior.
+ */
+function graphql_update_10400() :void {
+  \Drupal::configFactory()->getEditable('graphql.settings')
+    ->set('dataproducer_populate_default_values', FALSE)
+    ->save();
+}

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -93,8 +93,10 @@ class DataProducerPluginManager extends DefaultPluginManager {
 
     // We don't use dependency injection here to avoid a constructor signature
     // change.
-    // @phpcs:ignore @phpstan-ignore-next-line
+    // @phpcs:disable
+    // @phpstan-ignore-next-line
     $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values') ?? TRUE;
+    // @phpcs:enable
   }
 
   /**

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -92,7 +92,8 @@ class DataProducerPluginManager extends DefaultPluginManager {
     $this->resultCacheBackend = $resultCacheBackend;
 
     // We don't use dependency injection here to avoid a constructor signature
-    // change. @phpstan-ignore-next-line
+    // change.
+    // @phpcs:ignore
     $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values') ?? TRUE;
   }
 

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -93,7 +93,7 @@ class DataProducerPluginManager extends DefaultPluginManager {
 
     // We don't use dependency injection here to avoid a constructor signature
     // change.
-    // @phpcs:ignore
+    // @phpcs:ignore @phpstan-ignore-next-line
     $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values') ?? TRUE;
   }
 

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -92,8 +92,8 @@ class DataProducerPluginManager extends DefaultPluginManager {
     $this->resultCacheBackend = $resultCacheBackend;
 
     // We don't use dependency injection here to avoid a constructor signature
-    // change.
-    $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values', TRUE);
+    // change. @phpstan-ignore-next-line
+    $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values') ?? TRUE;
   }
 
   /**

--- a/src/Plugin/DataProducerPluginManager.php
+++ b/src/Plugin/DataProducerPluginManager.php
@@ -36,6 +36,13 @@ class DataProducerPluginManager extends DefaultPluginManager {
   protected $resultCacheBackend;
 
   /**
+   * Backwards compatibility flag to populate context defaults or not.
+   *
+   * @todo Remove in 5.x.
+   */
+  protected bool $populateContextDefaults = TRUE;
+
+  /**
    * DataProducerPluginManager constructor.
    *
    * @param bool|string $pluginSubdirectory
@@ -83,6 +90,18 @@ class DataProducerPluginManager extends DefaultPluginManager {
     $this->requestStack = $requestStack;
     $this->contextsManager = $contextsManager;
     $this->resultCacheBackend = $resultCacheBackend;
+
+    // We don't use dependency injection here to avoid a constructor signature
+    // change.
+    $this->populateContextDefaults = \Drupal::config('graphql.settings')->get('dataproducer_populate_default_values', TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createInstance($plugin_id, array $configuration = []) {
+    $configuration['dataproducer_populate_default_values'] = $this->populateContextDefaults;
+    return parent::createInstance($plugin_id, $configuration);
   }
 
   /**

--- a/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
@@ -50,8 +50,8 @@ abstract class DataProducerPluginBase extends PluginBase implements DataProducer
     if (!method_exists($this, 'resolve')) {
       throw new \LogicException('Missing data producer resolve method.');
     }
-    $populateDefaulktValues = $this->configuration['dataproducer_populate_default_values'] ?? TRUE;
-    $context = $populateDefaulktValues ? $this->getContextValuesWithDefaults() : $this->getContextValues();
+    $populateDefaultValues = $this->configuration['dataproducer_populate_default_values'] ?? TRUE;
+    $context = $populateDefaultValues ? $this->getContextValuesWithDefaults() : $this->getContextValues();
     return call_user_func_array(
       [$this, 'resolve'],
       array_values(array_merge($context, [$field]))

--- a/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
@@ -51,11 +51,26 @@ abstract class DataProducerPluginBase extends PluginBase implements DataProducer
       throw new \LogicException('Missing data producer resolve method.');
     }
 
-    $context = $this->getContextValues();
+    $context = $this->getContextValuesWithDefaults();
     return call_user_func_array(
       [$this, 'resolve'],
       array_values(array_merge($context, [$field]))
     );
+  }
+
+  /**
+   * Initializes all contexts and populates default values.
+   *
+   * We cannot use ::getContextValues() here because it does not work with
+   * default_value.
+   */
+  public function getContextValuesWithDefaults() {
+    $values = [];
+    foreach ($this->getContextDefinitions() as $name => $definition) {
+      $values[$name] = $this->getContext($name)->getContextValue();
+    }
+
+    return $values;
   }
 
 }

--- a/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
@@ -64,7 +64,7 @@ abstract class DataProducerPluginBase extends PluginBase implements DataProducer
    * We cannot use ::getContextValues() here because it does not work with
    * default_value.
    */
-  public function getContextValuesWithDefaults() {
+  public function getContextValuesWithDefaults(): array {
     $values = [];
     foreach ($this->getContextDefinitions() as $name => $definition) {
       $values[$name] = $this->getContext($name)->getContextValue();

--- a/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
+++ b/src/Plugin/GraphQL/DataProducer/DataProducerPluginBase.php
@@ -50,8 +50,8 @@ abstract class DataProducerPluginBase extends PluginBase implements DataProducer
     if (!method_exists($this, 'resolve')) {
       throw new \LogicException('Missing data producer resolve method.');
     }
-
-    $context = $this->getContextValuesWithDefaults();
+    $populateDefaulktValues = $this->configuration['dataproducer_populate_default_values'] ?? TRUE;
+    $context = $populateDefaulktValues ? $this->getContextValuesWithDefaults() : $this->getContextValues();
     return call_user_func_array(
       [$this, 'resolve'],
       array_values(array_merge($context, [$field]))

--- a/tests/src/Kernel/DataProducer/DefaultValueTest.php
+++ b/tests/src/Kernel/DataProducer/DefaultValueTest.php
@@ -2,7 +2,13 @@
 
 namespace Drupal\Tests\graphql\Kernel\DataProducer;
 
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\EntityLoad;
+use Drupal\media_test_source\Plugin\media\Source\Test;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use GraphQL\Deferred;
+use PHPUnit\Framework\Assert;
 
 /**
  * Context default value test.
@@ -24,4 +30,32 @@ class DefaultValueTest extends GraphQLTestBase {
     $this->assertSame('view', $context_values['access_operation']);
   }
 
+  /**
+   * Test that the legacy dataproducer_populate_default_values setting works.
+   */
+  public function testLegacyDefaultValueSetting(): void {
+    $this->container->get('config.factory')->getEditable('graphql.settings')
+      ->set('dataproducer_populate_default_values', FALSE)
+      ->save();
+    $manager = $this->container->get('plugin.manager.graphql.data_producer');
+
+    // Manipulate the plugin definitions to use our test class for entity_load.
+    $definitions = $manager->getDefinitions();
+    $definitions['entity_load']['class'] = TestLegacyEntityLoad::class;
+    $reflection = new \ReflectionClass($manager);
+    $property = $reflection->getProperty('definitions');
+    $property->setAccessible(TRUE);
+    $property->setValue($manager, $definitions);
+
+    $this->executeDataProducer('entity_load', ['type' => 'node']);
+  }
+
+}
+
+class TestLegacyEntityLoad extends EntityLoad {
+  public function resolve($type, $id, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+    Assert::assertNull($access);
+    Assert::assertNull($accessOperation);
+    return NULL;
+  }
 }

--- a/tests/src/Kernel/DataProducer/DefaultValueTest.php
+++ b/tests/src/Kernel/DataProducer/DefaultValueTest.php
@@ -21,7 +21,7 @@ class DefaultValueTest extends GraphQLTestBase {
     // Only type is required.
     $plugin->setContextValue('type', 'node');
     $context_values = $plugin->getContextValuesWithDefaults();
-    $this->assertSame(TRUE, $context_values['access']);
+    $this->assertTrue($context_values['access']);
     $this->assertSame('view', $context_values['access_operation']);
   }
 

--- a/tests/src/Kernel/DataProducer/DefaultValueTest.php
+++ b/tests/src/Kernel/DataProducer/DefaultValueTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Tests\graphql\Kernel\DataProducer;
+
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+
+/**
+ * Context default value test.
+ *
+ * @group graphql
+ */
+class DefaultValueTest extends GraphQLTestBase {
+
+
+  /**
+   * Test that the entity_load data producer has the correct default values.
+   */
+  public function testEntityLoadDefaultValue(): void {
+    $manager = $this->container->get('plugin.manager.graphql.data_producer');
+    $plugin = $manager->createInstance('entity_load');
+    // Only type is required.
+    $plugin->setContextValue('type', 'node');
+    $context_values = $plugin->getContextValuesWithDefaults();
+    $this->assertSame(TRUE, $context_values['access']);
+    $this->assertSame('view', $context_values['access_operation']);
+  }
+
+}

--- a/tests/src/Kernel/DataProducer/DefaultValueTest.php
+++ b/tests/src/Kernel/DataProducer/DefaultValueTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\graphql\Kernel\DataProducer;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\Entity\EntityLoad;
-use Drupal\media_test_source\Plugin\media\Source\Test;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use GraphQL\Deferred;
 use PHPUnit\Framework\Assert;
@@ -32,16 +31,18 @@ class DefaultValueTest extends GraphQLTestBase {
 
   /**
    * Test that the legacy dataproducer_populate_default_values setting works.
+   *
+   * @dataProvider settingsProvider
    */
-  public function testLegacyDefaultValueSetting(): void {
+  public function testLegacyDefaultValueSetting(bool $populate_setting, string $testClass): void {
     $this->container->get('config.factory')->getEditable('graphql.settings')
-      ->set('dataproducer_populate_default_values', FALSE)
+      ->set('dataproducer_populate_default_values', $populate_setting)
       ->save();
     $manager = $this->container->get('plugin.manager.graphql.data_producer');
 
     // Manipulate the plugin definitions to use our test class for entity_load.
     $definitions = $manager->getDefinitions();
-    $definitions['entity_load']['class'] = TestLegacyEntityLoad::class;
+    $definitions['entity_load']['class'] = $testClass;
     $reflection = new \ReflectionClass($manager);
     $property = $reflection->getProperty('definitions');
     $property->setAccessible(TRUE);
@@ -50,12 +51,48 @@ class DefaultValueTest extends GraphQLTestBase {
     $this->executeDataProducer('entity_load', ['type' => 'node']);
   }
 
+  /**
+   * Data provider for the testLegacyDefaultValueSetting test.
+   */
+  public function settingsProvider(): array {
+    return [
+      [FALSE, TestLegacyEntityLoad::class],
+      [TRUE, TestNewEntityLoad::class],
+    ];
+  }
+
 }
 
+/**
+ * Helper class to test the legacy behavior.
+ */
 class TestLegacyEntityLoad extends EntityLoad {
+
+  /**
+   * {@inheritdoc}
+   */
   public function resolve($type, $id, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+    // Old behavior: no default values applied, so we get NULL here.
     Assert::assertNull($access);
     Assert::assertNull($accessOperation);
     return NULL;
   }
+
+}
+
+/**
+ * Helper class to test the new behavior.
+ */
+class TestNewEntityLoad extends EntityLoad {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve($type, $id, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context): ?Deferred {
+    // New behavior: default values are applied.
+    Assert::assertTrue($access);
+    Assert::assertSame('view', $accessOperation);
+    return NULL;
+  }
+
 }

--- a/tests/src/Kernel/DataProducer/DefaultValueTest.php
+++ b/tests/src/Kernel/DataProducer/DefaultValueTest.php
@@ -11,7 +11,6 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
  */
 class DefaultValueTest extends GraphQLTestBase {
 
-
   /**
    * Test that the entity_load data producer has the correct default values.
    */

--- a/tests/src/Kernel/DataProducer/EntityMultipleTest.php
+++ b/tests/src/Kernel/DataProducer/EntityMultipleTest.php
@@ -78,10 +78,6 @@ class EntityMultipleTest extends GraphQLTestBase {
       'type' => $this->node1->getEntityTypeId(),
       'bundles' => [$this->node1->bundle(), $this->node2->bundle()],
       'ids' => [$this->node1->id(), $this->node2->id(), $this->node3->id()],
-      // @todo We need to set these default values here to make the access
-      // handling work. Ideally that should not be needed.
-      'access' => TRUE,
-      'access_operation' => 'view',
     ]);
 
     $nids = array_values(array_map(function (NodeInterface $item) {
@@ -104,8 +100,6 @@ class EntityMultipleTest extends GraphQLTestBase {
     $result = $this->executeDataProducer('entity_load_multiple', [
       'type' => $this->node1->getEntityTypeId(),
       'ids' => [NULL],
-      'access' => TRUE,
-      'access_operation' => 'view',
     ]);
 
     $this->assertSame([], $result);


### PR DESCRIPTION
Fix for #1233.

It is a bit unfortunate that Drupal core does not provide a good API function to get context values with default values populated, but not a big problem. We can implement that ourselves.

Now we could also update a lot of `resolve()` function signatures to remove the `?` null type parameter, because now default values will always be passed.

Should we do it as part of this change or do we consider this an API break?