### PR TITLE
drupal-graphql#1338: Fix error while trying to load an entity when there is no translation for a given language

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoad.php
@@ -171,7 +171,7 @@ class EntityLoad extends DataProducerPluginBase implements ContainerFactoryPlugi
       }
 
       // Get the correct translation.
-      if (isset($language) && $language !== $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+      if (isset($language) && $language !== $entity->language()->getId() && $entity instanceof TranslatableInterface && $entity->hasTranslation($language)) {
         $entity = $entity->getTranslation($language);
         $entity->addCacheContexts(["static:language:{$language}"]);
       }

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityLoadByUuid.php
@@ -164,7 +164,7 @@ class EntityLoadByUuid extends DataProducerPluginBase implements ContainerFactor
       }
 
       // Get the correct translation.
-      if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+      if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface && $entity->hasTranslation($language)) {
         $entity = $entity->getTranslation($language);
         $entity->addCacheContexts(["static:language:{$language}"]);
       }

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslation.php
@@ -103,7 +103,7 @@ class EntityTranslation extends DataProducerPluginBase implements ContainerFacto
    * @return \Drupal\Core\Entity\EntityInterface|null
    */
   public function resolve(EntityInterface $entity, $language, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
-    if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
+    if ($entity instanceof TranslatableInterface && $entity->isTranslatable() && $entity->hasTranslation($language)) {
       $entity = $entity->getTranslation($language);
       $entity->addCacheContexts(["static:language:{$language}"]);
       // Check if the passed user (or current user if none is passed) has access

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
@@ -107,7 +107,7 @@ class EntityTranslations extends DataProducerPluginBase implements ContainerFact
 
       return array_map(function (LanguageInterface $language) use ($entity, $access, $accessOperation, $accessUser, $context) {
         $langcode = $language->getId();
-        if (!$entity->hasTranslation($language)) {
+        if (!$entity->hasTranslation($langcode)) {
           return NULL;
         }
         $entity = $entity->getTranslation($langcode);

--- a/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/EntityTranslations.php
@@ -107,6 +107,9 @@ class EntityTranslations extends DataProducerPluginBase implements ContainerFact
 
       return array_map(function (LanguageInterface $language) use ($entity, $access, $accessOperation, $accessUser, $context) {
         $langcode = $language->getId();
+        if (!$entity->hasTranslation($language)) {
+          return NULL;
+        }
         $entity = $entity->getTranslation($langcode);
         $entity->addCacheContexts(["static:language:{$langcode}"]);
         if ($access) {

--- a/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
+++ b/src/Plugin/GraphQL/DataProducer/Routing/RouteEntity.php
@@ -125,7 +125,7 @@ class RouteEntity extends DataProducerPluginBase implements ContainerFactoryPlug
         }
 
         // Get the correct translation.
-        if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+        if (isset($language) && $language != $entity->language()->getId() && $entity instanceof TranslatableInterface && $entity->hasTranslation($language)) {
           $entity = $entity->getTranslation($language);
           $entity->addCacheContexts(["static:language:{$language}"]);
         }

--- a/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
+++ b/src/Plugin/GraphQL/DataProducer/Taxonomy/TaxonomyLoadTree.php
@@ -174,7 +174,7 @@ class TaxonomyLoadTree extends DataProducerPluginBase implements ContainerFactor
       foreach ($entities as $id => $entity) {
         $context->addCacheableDependency($entities[$id]);
 
-        if (isset($language) && $language !== $entities[$id]->language()->getId() && $entities[$id] instanceof TranslatableInterface) {
+        if (isset($language) && $language !== $entities[$id]->language()->getId() && $entities[$id] instanceof TranslatableInterface && $entities[$id]->hasTranslation($language)) {
           $entities[$id] = $entities[$id]->getTranslation($language);
           $entities[$id]->addCacheContexts(["static:language:{$language}"]);
         }


### PR DESCRIPTION
Initial described here https://github.com/drupal-graphql/graphql/issues/1322
and completed here https://github.com/drupal-graphql/graphql/pull/1388

Here are some additional fixes for some dataProducers.