### PR TITLE
test(phpunit): Replace deprecated getMockForAbstractClass() and getName() calls

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -105,7 +105,7 @@ jobs:
         # Pin the exact Coder version to upgrade manually when we want to.
         run: |
           composer --no-interaction --no-progress require \
-            phpstan/phpstan:^1.11.2 \
+            phpstan/phpstan:^1.11.9 \
             mglaman/phpstan-drupal:^1.1.2 \
             phpstan/phpstan-deprecation-rules:^1.0.0 \
             jangregor/phpstan-prophecy:^1.0.0 \

--- a/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
+++ b/src/Plugin/GraphQL/DataProducer/Entity/Fields/Image/ImageDerivative.php
@@ -98,11 +98,10 @@ class ImageDerivative extends DataProducerPluginBase implements ContainerFactory
     $metadata->addCacheableDependency($access);
     if ($access->isAllowed() && $image_style = ImageStyle::load($style)) {
 
-      // @phpstan-ignore-next-line
       $width = $entity->width;
-      // @phpstan-ignore-next-line
       $height = $entity->height;
 
+      // @phpstan-ignore-next-line
       if (empty($width) || empty($height)) {
         /** @var \Drupal\Core\Image\ImageInterface $image */
         $image = \Drupal::service('image.factory')->get($entity->getFileUri());

--- a/tests/src/Kernel/AlterableSchemaTest.php
+++ b/tests/src/Kernel/AlterableSchemaTest.php
@@ -156,7 +156,7 @@ class AlterableSchemaTest extends GraphQLTestBase {
       ->willReturn('');
 
     // Different extension definition for different tests.
-    switch ($this->getName()) {
+    switch ($this->name()) {
       case 'testEmptySchemaExtensionAlteredQueryResultPropertyAdded':
         $extensionDefinition = '';
         break;

--- a/tests/src/Kernel/AlterableSchemaTest.php
+++ b/tests/src/Kernel/AlterableSchemaTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\graphql\Kernel;
 
 use Drupal\graphql\GraphQL\ResolverRegistry;
-use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use Drupal\graphql\Plugin\SchemaExtensionPluginInterface;
 use Drupal\graphql\Plugin\SchemaExtensionPluginManager;
 use Drupal\Tests\graphql\Kernel\Schema\AlterableComposableTestSchema;
 
@@ -148,10 +148,8 @@ class AlterableSchemaTest extends GraphQLTestBase {
       ->getMock();
 
     // Adds extra extension in order to test alter extension data event.
-    $extensions['graphql_alterable_schema_test'] = $this->getMockBuilder(SdlSchemaExtensionPluginBase::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods(['getBaseDefinition', 'getExtensionDefinition'])
-      ->getMockForAbstractClass();
+    $extensions['graphql_alterable_schema_test'] = $this->getMockBuilder(SchemaExtensionPluginInterface::class)
+      ->getMock();
 
     $extensions['graphql_alterable_schema_test']->expects(static::any())
       ->method('getBaseDefinition')
@@ -193,7 +191,7 @@ class AlterableSchemaTest extends GraphQLTestBase {
         $this->container->get('event_dispatcher'),
       ])
       ->onlyMethods(['getSchemaDefinition', 'getResolverRegistry'])
-      ->getMockForAbstractClass();
+      ->getMock();
 
     $this->schema->expects(static::any())
       ->method('getSchemaDefinition')

--- a/tests/src/Kernel/AlterableSchemaTest.php
+++ b/tests/src/Kernel/AlterableSchemaTest.php
@@ -156,7 +156,9 @@ class AlterableSchemaTest extends GraphQLTestBase {
       ->willReturn('');
 
     // Different extension definition for different tests.
-    switch ($this->name()) {
+    // PHPUnit compatibility: remove once support for Drupal 10.2 is dropped.
+    $methodName = method_exists($this, 'name') ? 'name' : 'getName';
+    switch ($this->$methodName()) {
       case 'testEmptySchemaExtensionAlteredQueryResultPropertyAdded':
         $extensionDefinition = '';
         break;

--- a/tests/src/Traits/MockingTrait.php
+++ b/tests/src/Traits/MockingTrait.php
@@ -145,7 +145,7 @@ trait MockingTrait {
         ['development' => FALSE],
       ])
       ->onlyMethods(['getSchemaDefinition', 'getResolverRegistry'])
-      ->getMockForAbstractClass();
+      ->getMock();
 
     $this->schema->expects(static::any())
       ->method('getSchemaDefinition')


### PR DESCRIPTION
Discovered in #1407 