### PR TITLE
fix(MenuLinkUrl): Handle translation of URls

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkUrl.php
+++ b/src/Plugin/GraphQL/DataProducer/Menu/MenuLink/MenuLinkUrl.php
@@ -1,40 +1,85 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\graphql\Plugin\GraphQL\DataProducer\Menu\MenuLink;
 
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Menu\MenuLinkInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\graphql\Attribute\DataProducer;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Returns the URL object of a menu link.
  *
  * @todo Fix input and output context type.
- *
- * @DataProducer(
- *   id = "menu_link_url",
- *   name = @Translation("Menu link url"),
- *   description = @Translation("Returns the URL of a menu link."),
- *   produces = @ContextDefinition("any",
- *     label = @Translation("URL")
- *   ),
- *   consumes = {
- *     "link" = @ContextDefinition("any",
- *       label = @Translation("Menu link")
- *     )
- *   }
- * )
  */
-class MenuLinkUrl extends DataProducerPluginBase {
+#[DataProducer(
+  id: 'menu_link_url',
+  name: new TranslatableMarkup('Menu link url'),
+  description: new TranslatableMarkup('Returns the URL of a menu link.'),
+  produces: new ContextDefinition(
+    data_type: 'any',
+    label: new TranslatableMarkup('URL'),
+  ),
+  consumes: [
+    'link' => new ContextDefinition(
+      data_type: 'any',
+      label: new TranslatableMarkup('Menu link'),
+    ),
+  ],
+)]
+class MenuLinkUrl extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+  use DependencySerializationTrait;
+
+  /**
+   * The language manager service.
+   */
+  protected LanguageManagerInterface $languageManager;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $pluginId, $pluginDefinition) {
+    return new static(
+      $configuration,
+      $pluginId,
+      $pluginDefinition,
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * MenuLinkUrl constructor.
+   */
+  public function __construct(array $configuration, string $pluginId, array $pluginDefinition, LanguageManagerInterface $languageManager) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->languageManager = $languageManager;
+  }
 
   /**
    * Resolver.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkInterface $link
-   *
-   * @return \Drupal\Core\Url
    */
-  public function resolve(MenuLinkInterface $link) {
-    return $link->getUrlObject();
+  public function resolve(MenuLinkInterface $link, FieldContext $context): Url {
+    $url = $link->getUrlObject();
+
+    if ($langcode = $context->getContextLanguage()) {
+      if ($language = $this->languageManager->getLanguage($langcode)) {
+        $url->setOption('language', $language);
+      }
+      $context->addCacheContexts(['languages:language_url']);
+    }
+
+    return $url;
   }
 
 }


### PR DESCRIPTION
This PR is somewhat related to https://github.com/drupal-graphql/graphql/pull/809 which adds multilingual support for menu links. That works well, however in our case we are passing the language parameter to the menu, and that seems to not get carried away to the URL.

The label is translated fine but the URL itself (which in our case is not translated in the menu item its just the original URL) is not really picked up..the link is to a node so it should be possible to return the translated URL

Our resolvers look like this : 

Getting the menu : 

```
// Menu query.
$registry->addFieldResolver('Query', 'menu',
  $builder->produce('menu_load', [
    'id' => $builder->fromArgument('name'),
    'access' => $builder->fromValue(FALSE),
    'language' => $builder->fromArgument('language'),
  ])
);
```

getting the menu items : 

```
// Menu items.
$registry->addFieldResolver('Menu', 'items',
  $builder->produce('menu_links', [
    'menu' => $builder->fromParent(),
  ])
);
```

Item URL : 

```
// Menu url.
$registry->addFieldResolver('MenuItem', 'url',
  $builder->produce('menu_link_url', [
    'link' => $builder->produce('menu_tree_link', [
      'element' => $builder->fromParent(),
    ]),
  ])
);
```